### PR TITLE
V3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Represents the **NuGet** versions.
 
+## v3.1.0
+- *Enhancement:* Updated all package depenedencies to latest.
+- *Enhancement:* The `GenericTester` updated to support `IHostStartup` to enable shared host dependency injection configuration.
+- *Enhancement:* Added `IEventExpectations<TSelf>` and `ILoggerExpectations<TSelf>` support to `GenericTester` and `ValidationTester`.
+- *Enhancement:* Moved the `CreateServiceBusMessage` and related methods from `FunctionTesterBase` up the inheritance hierarchy to `TesterBase<TSelf>` to enable broader usage.
+- *Enhancement:* Added `ExpectEventFromJsonResource` and `ExpectDestinationEventFromJsonResource` expectations to simplify specification versus having to instantiate `EventData`.
+- *Enhancement:* The `JsonElementComparer` now defaults to case-insensitive comparison.
+- *Enhancement:* The event expectations comparer
+
 ## v3.0.0
 - *Enhancement:* Updated `CoreEx` dependencies to `3.0.0` as breaking changes were introduced. There are no breaking changes within `UnitTestEx` as a result; primarily related to the key `CoreEx` dependency.
   - Given the `CoreEx` dependency, explicitly the creation of the new `CoreEx.AspNetCore`, this `UnitTextEx` version is not backwards compatible with previous versions of `CoreEx` (i.e. `2.x.x`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Represents the **NuGet** versions.
 - *Enhancement:* Moved the `CreateServiceBusMessage` and related methods from `FunctionTesterBase` up the inheritance hierarchy to `TesterBase<TSelf>` to enable broader usage.
 - *Enhancement:* Added `ExpectEventFromJsonResource` and `ExpectDestinationEventFromJsonResource` expectations to simplify specification versus having to instantiate `EventData`.
 - *Enhancement:* The `JsonElementComparer` now defaults to case-insensitive comparison.
-- *Enhancement:* The event expectations comparer
+- *Enhancement:* All internal usage of the `ObjectComparer` replaced with usage of the `JsonElementComparer` to break external dependency. All `MembersToIgnore` have been replaced with `PathsToIgnore` (being the fully-qualified JSON path) as this is more explicit and less error prone. The `ObjectComparer` has been flagged as `Obsolete` and will be removed in a later version.
 
 ## v3.0.0
 - *Enhancement:* Updated `CoreEx` dependencies to `3.0.0` as breaking changes were introduced. There are no breaking changes within `UnitTestEx` as a result; primarily related to the key `CoreEx` dependency.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.0.0</Version>
+		<Version>3.1.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx.MSTest/GenericTester.cs
+++ b/src/UnitTestEx.MSTest/GenericTester.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
+using System;
+
 namespace UnitTestEx.MSTest
 {
     /// <summary>
@@ -10,7 +13,14 @@ namespace UnitTestEx.MSTest
         /// <summary>
         /// Creates a new instance of the <see cref="GenericTester"/> class.
         /// </summary>
-        /// <returns>The <see cref="GenericTester"/>.</returns>
-        public static Internal.GenericTester Create() => new();
+        /// <returns>The <see cref="Internal.GenericTester{TEntryPoint}"/>.</returns>
+        public static Internal.GenericTester<HostStartup> Create() => Create<HostStartup>();
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="GenericTester"/> class.
+        /// </summary>
+        /// <typeparam name="TEntryPoint">The <see cref="IHostStartup"/> <see cref="Type"/>.</typeparam>
+        /// <returns>The <see cref="Internal.GenericTester{TEntryPoint}"/>.</returns>
+        public static Internal.GenericTester<TEntryPoint> Create<TEntryPoint>() where TEntryPoint : IHostStartup, new() => new();
     }
 }

--- a/src/UnitTestEx.MSTest/Internal/GenericTesterT.cs
+++ b/src/UnitTestEx.MSTest/Internal/GenericTesterT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using UnitTestEx.Generic;
 
 namespace UnitTestEx.MSTest.Internal
@@ -7,7 +8,7 @@ namespace UnitTestEx.MSTest.Internal
     /// <summary>
     /// Provides the <b>MSTest</b> generic testing capability.
     /// </summary>
-    public class GenericTester : GenericTesterBase<ValidationTester>
+    public class GenericTester<TEntryPoint> : GenericTesterBase<TEntryPoint, GenericTester<TEntryPoint>> where TEntryPoint : IHostStartup, new()
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericTester"/> class.

--- a/src/UnitTestEx.MSTest/Internal/ValidationTesterT.cs
+++ b/src/UnitTestEx.MSTest/Internal/ValidationTesterT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using CoreEx.Validation;
 using UnitTestEx.Generic;
 
@@ -8,10 +9,10 @@ namespace UnitTestEx.MSTest.Internal
     /// <summary>
     /// Provides the <b>MSTest</b> <see cref="IValidator"/> testing capability.
     /// </summary>
-    public class ValidationTester : ValidationTesterBase<ValidationTester>
+    public class ValidationTester<TEntryPoint> : ValidationTesterBase<TEntryPoint, ValidationTester<TEntryPoint>> where TEntryPoint : IHostStartup, new()
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationTester"/> class.
+        /// Initializes a new instance of the <see cref="ValidationTester{TEntryPoint}"/> class.
         /// </summary>
         internal ValidationTester() : base(new MSTestImplementor()) { }
     }

--- a/src/UnitTestEx.MSTest/ObjectComparer.cs
+++ b/src/UnitTestEx.MSTest/ObjectComparer.cs
@@ -9,6 +9,7 @@ namespace UnitTestEx.MSTest
     /// <summary>
     /// Deep object comparer.
     /// </summary>
+    [Obsolete($"This is being replaced by the {nameof(UnitTestEx.Abstractions.JsonElementComparer)} and usage of paths to ignore (versus members) to be more explicit.")]
     public static class ObjectComparer
     {
         /// <summary>

--- a/src/UnitTestEx.MSTest/ValidationTester.cs
+++ b/src/UnitTestEx.MSTest/ValidationTester.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using CoreEx.Validation;
+using System;
 
 namespace UnitTestEx.MSTest
 {
@@ -12,7 +14,15 @@ namespace UnitTestEx.MSTest
         /// <summary>
         /// Creates a new instance of the <see cref="ValidationTester"/> class.
         /// </summary>
+        /// <returns>The <see cref="Internal.ValidationTester{TEntryPoint}"/>.</returns>
         /// <returns>The <see cref="ValidationTester"/>.</returns>
-        public static Internal.ValidationTester Create() => new();
+        public static Internal.ValidationTester<HostStartup> Create() => Create<HostStartup>();
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="GenericTester"/> class.
+        /// </summary>
+        /// <typeparam name="TEntryPoint">The <see cref="IHostStartup"/> <see cref="Type"/>.</typeparam>
+        /// <returns>The <see cref="Internal.ValidationTester{TEntryPoint}"/>.</returns>
+        public static Internal.ValidationTester<TEntryPoint> Create<TEntryPoint>() where TEntryPoint : IHostStartup, new() => new();
     }
 }

--- a/src/UnitTestEx.NUnit/GenericTester.cs
+++ b/src/UnitTestEx.NUnit/GenericTester.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
+using System;
+
 namespace UnitTestEx.NUnit
 {
     /// <summary>
@@ -10,7 +13,14 @@ namespace UnitTestEx.NUnit
         /// <summary>
         /// Creates a new instance of the <see cref="GenericTester"/> class.
         /// </summary>
-        /// <returns>The <see cref="GenericTester"/>.</returns>
-        public static Internal.GenericTester Create() => new();
+        /// <returns>The <see cref="Internal.GenericTester{TEntryPoint}"/>.</returns>
+        public static Internal.GenericTester<HostStartup> Create() => Create<HostStartup>();
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="GenericTester"/> class.
+        /// </summary>
+        /// <typeparam name="TEntryPoint">The <see cref="IHostStartup"/> <see cref="Type"/>.</typeparam>
+        /// <returns>The <see cref="Internal.GenericTester{TEntryPoint}"/>.</returns>
+        public static Internal.GenericTester<TEntryPoint> Create<TEntryPoint>() where TEntryPoint : IHostStartup, new() => new();
     }
 }

--- a/src/UnitTestEx.NUnit/Internal/GenericTesterT.cs
+++ b/src/UnitTestEx.NUnit/Internal/GenericTesterT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using UnitTestEx.Generic;
 
 namespace UnitTestEx.NUnit.Internal
@@ -7,7 +8,7 @@ namespace UnitTestEx.NUnit.Internal
     /// <summary>
     /// Provides the <b>NUnit</b> generic testing capability.
     /// </summary>
-    public class GenericTester : GenericTesterBase<GenericTester>
+    public class GenericTester<TEntryPoint> : GenericTesterBase<TEntryPoint, GenericTester<TEntryPoint>> where TEntryPoint : IHostStartup, new()
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericTester"/> class.

--- a/src/UnitTestEx.NUnit/Internal/ValidationTesterT.cs
+++ b/src/UnitTestEx.NUnit/Internal/ValidationTesterT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using CoreEx.Validation;
 using UnitTestEx.Generic;
 
@@ -8,10 +9,10 @@ namespace UnitTestEx.NUnit.Internal
     /// <summary>
     /// Provides the <b>NUnit</b> <see cref="IValidator"/> testing capability.
     /// </summary>
-    public class ValidationTester : ValidationTesterBase<ValidationTester>
+    public class ValidationTester<TEntryPoint> : ValidationTesterBase<TEntryPoint, ValidationTester<TEntryPoint>> where TEntryPoint : IHostStartup, new()
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationTester"/> class.
+        /// Initializes a new instance of the <see cref="ValidationTester{TEntryPoint}"/> class.
         /// </summary>
         internal ValidationTester() : base(new NUnitTestImplementor()) { }
     }

--- a/src/UnitTestEx.NUnit/ObjectComparer.cs
+++ b/src/UnitTestEx.NUnit/ObjectComparer.cs
@@ -9,6 +9,7 @@ namespace UnitTestEx.NUnit
     /// <summary>
     /// Deep object comparer.
     /// </summary>
+    [Obsolete($"This is being replaced by the {nameof(UnitTestEx.Abstractions.JsonElementComparer)} and usage of paths to ignore (versus members) to be more explicit.")]
     public static class ObjectComparer
     {
         /// <summary>

--- a/src/UnitTestEx.NUnit/ValidationTester.cs
+++ b/src/UnitTestEx.NUnit/ValidationTester.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using CoreEx.Validation;
+using System;
 
 namespace UnitTestEx.NUnit
 {
@@ -12,7 +14,15 @@ namespace UnitTestEx.NUnit
         /// <summary>
         /// Creates a new instance of the <see cref="ValidationTester"/> class.
         /// </summary>
+        /// <returns>The <see cref="Internal.ValidationTester{TEntryPoint}"/>.</returns>
         /// <returns>The <see cref="ValidationTester"/>.</returns>
-        public static Internal.ValidationTester Create() => new();
+        public static Internal.ValidationTester<HostStartup> Create() => Create<HostStartup>();
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="GenericTester"/> class.
+        /// </summary>
+        /// <typeparam name="TEntryPoint">The <see cref="IHostStartup"/> <see cref="Type"/>.</typeparam>
+        /// <returns>The <see cref="Internal.ValidationTester{TEntryPoint}"/>.</returns>
+        public static Internal.ValidationTester<TEntryPoint> Create<TEntryPoint>() where TEntryPoint : IHostStartup, new() => new();
     }
 }

--- a/src/UnitTestEx.Xunit/Internal/GenericTesterT.cs
+++ b/src/UnitTestEx.Xunit/Internal/GenericTesterT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using UnitTestEx.Generic;
 using Xunit.Abstractions;
 
@@ -8,10 +9,10 @@ namespace UnitTestEx.Xunit.Internal
     /// <summary>
     /// Provides the <b>Xunit</b> generic testing capability.
     /// </summary>
-    public class GenericTester : GenericTesterBase<GenericTester>
+    public class GenericTester<TEntryPoint> : GenericTesterBase<TEntryPoint, GenericTester<TEntryPoint>> where TEntryPoint : IHostStartup, new()
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="GenericTester"/> class.
+        /// Initializes a new instance of the <see cref="GenericTester{TEntryPoint}"/> class.
         /// </summary>
         /// <param name="output">The <see cref="ITestOutputHelper"/>.</param>
         internal GenericTester(ITestOutputHelper output) : base(new XunitTestImplementor(output)) { }

--- a/src/UnitTestEx.Xunit/Internal/ObjectComparer.cs
+++ b/src/UnitTestEx.Xunit/Internal/ObjectComparer.cs
@@ -8,6 +8,7 @@ namespace UnitTestEx.Xunit.Internal
     /// <summary>
     /// Deep object comparer.
     /// </summary>
+    [Obsolete($"This is being replaced by the {nameof(UnitTestEx.Abstractions.JsonElementComparer)} and usage of paths to ignore (versus members) to be more explicit.")]
     public class ObjectComparer
     {
         private readonly XunitTestImplementor _implementor;

--- a/src/UnitTestEx.Xunit/Internal/ValidationTesterT.cs
+++ b/src/UnitTestEx.Xunit/Internal/ValidationTesterT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using CoreEx.Validation;
 using UnitTestEx.Generic;
 using Xunit.Abstractions;
@@ -9,10 +10,10 @@ namespace UnitTestEx.Xunit.Internal
     /// <summary>
     /// Provides the <b>Xunit</b> <see cref="IValidator"/> testing capability.
     /// </summary>
-    public class ValidationTester : ValidationTesterBase<ValidationTester>
+    public class ValidationTester<TEntryPoint> : ValidationTesterBase<TEntryPoint, ValidationTester<TEntryPoint>> where TEntryPoint : IHostStartup, new()
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationTester"/> class.
+        /// Initializes a new instance of the <see cref="ValidationTester{TEntryPoint}"/> class.
         /// </summary>
         /// <param name="output">The <see cref="ITestOutputHelper"/>.</param>
         internal ValidationTester(ITestOutputHelper output) : base(new XunitTestImplementor(output)) { }

--- a/src/UnitTestEx.Xunit/UnitTestBase.cs
+++ b/src/UnitTestEx.Xunit/UnitTestBase.cs
@@ -93,6 +93,7 @@ namespace UnitTestEx.Xunit
         /// <summary>
         /// Gets the <see cref="Internal.ObjectComparer"/>.
         /// </summary>
+        [Obsolete($"This is being replaced by the {nameof(UnitTestEx.Abstractions.JsonElementComparer)} and usage of paths to ignore (versus members) to be more explicit.")]
         protected ObjectComparer ObjectComparer => new(new XunitTestImplementor(Output));
     }
 }

--- a/src/UnitTestEx.Xunit/UnitTestBase.cs
+++ b/src/UnitTestEx.Xunit/UnitTestBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using CoreEx.Hosting;
 using CoreEx.Validation;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using System;
@@ -55,10 +56,18 @@ namespace UnitTestEx.Xunit
         /// Provides the <b>Xunit</b> <see cref="IValidator"/> testing capability.
         /// </summary>
         /// <param name="userName">The user name (<c>null</c> indicates to use the existing <see cref="CoreEx.ExecutionContext.Current"/> <see cref="CoreEx.ExecutionContext.UserName"/> where configured).</param>
-        /// <returns>The <see cref="ValidationTester"/>.</returns>
-        protected ValidationTester CreateValidationTester(string? userName = null)
+        /// <returns>The <see cref="ValidationTester{TEntryPoint}"/>.</returns>
+        protected ValidationTester<HostStartup> CreateValidationTester(string? userName = null) => CreateValidationTester<HostStartup>(userName);
+
+        /// <summary>
+        /// Provides the <b>Xunit</b> <see cref="IValidator"/> testing capability.
+        /// </summary>
+        /// <typeparam name="TEntryPoint">The <see cref="IHostStartup"/> <see cref="Type"/>.</typeparam>
+        /// <param name="userName">The user name (<c>null</c> indicates to use the existing <see cref="CoreEx.ExecutionContext.Current"/> <see cref="CoreEx.ExecutionContext.UserName"/> where configured).</param>
+        /// <returns>The <see cref="ValidationTester{TEntryPoint}"/>.</returns>
+        protected ValidationTester<TEntryPoint> CreateValidationTester<TEntryPoint>(string? userName = null) where TEntryPoint : IHostStartup, new()
         {
-            var vt = new ValidationTester(Output);
+            var vt = new ValidationTester<TEntryPoint>(Output);
             vt.UseUser(userName);
             return vt;
         }
@@ -66,10 +75,17 @@ namespace UnitTestEx.Xunit
         /// <summary>
         /// Provides the <b>Xunit</b> generic testing capability.
         /// </summary>
-        /// <returns>The <see cref="GenericTester"/>.</returns>
-        protected GenericTester CreateGenericTester(string? userName = null)
+        /// <returns>The <see cref="GenericTester{TEntryPoint}"/>.</returns>
+        protected GenericTester<HostStartup> CreateGenericTester(string? userName = null) => CreateGenericTester<HostStartup>(userName);
+
+        /// <summary>
+        /// Provides the <b>Xunit</b> generic testing capability.
+        /// </summary>
+        /// <typeparam name="TEntryPoint">The <see cref="IHostStartup"/> <see cref="Type"/>.</typeparam>
+        /// <returns>The <see cref="GenericTester{TEntryPoint}"/>.</returns>
+        protected GenericTester<TEntryPoint> CreateGenericTester<TEntryPoint>(string? userName = null) where TEntryPoint : IHostStartup, new()
         {
-            var gt = new GenericTester(Output);
+            var gt = new GenericTester<TEntryPoint>(Output);
             gt.UseUser(userName);
             return gt;
         }

--- a/src/UnitTestEx/Abstractions/JsonElementComparer.cs
+++ b/src/UnitTestEx/Abstractions/JsonElementComparer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +15,17 @@ namespace UnitTestEx.Abstractions
     /// <remarks>Influenced by <see href="https://stackoverflow.com/questions/60580743/what-is-equivalent-in-jtoken-deepequals-in-system-text-json"/>.</remarks>
     public sealed class JsonElementComparer : IEqualityComparer<JsonElement>, IEqualityComparer<string>
     {
+        private static JsonElementComparer _default = new(20);
+
+        /// <summary>
+        /// Gets or sets the default <see cref="JsonElementComparer"/> instance.
+        /// </summary>
+        public static JsonElementComparer Default
+        {
+            get => _default;
+            set => _default = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonElementComparer"/> class.
         /// </summary>
@@ -36,6 +48,52 @@ namespace UnitTestEx.Abstractions
         /// </summary>
         /// <remarks>Defaults to <see cref="StringComparer.InvariantCultureIgnoreCase"/>.</remarks>
         public IEqualityComparer<string>? PathComparer { get; set; }
+
+        /// <summary>
+        /// Compare two object values for equality; each value is JSON-serialized (uses <see cref="CoreEx.Json.JsonSerializer.Default"/>) and then compared.
+        /// </summary>
+        /// <param name="left">The left value.</param>
+        /// <param name="right">The right value.</param>
+        /// <param name="pathsToIgnore">Optional list of paths to exclude from the comparison.</param>
+        /// <returns>The resulting comparison error message; <c>null</c> indicates equality.</returns>
+        public string? CompareValues(object? left, object? right, params string[] pathsToIgnore)
+            => CompareValues(left, right, CoreEx.Json.JsonSerializer.Default, pathsToIgnore);
+
+        /// <summary>
+        /// Compare two object values for equality; each value is JSON-serialized (uses specified <paramref name="jsonSerializer"/>) and then compared.
+        /// </summary>
+        /// <param name="left">The left value.</param>
+        /// <param name="right">The right value.</param>
+        /// <param name="jsonSerializer">The <see cref="CoreEx.Json.IJsonSerializer"/>.</param>
+        /// <param name="pathsToIgnore">Optional list of paths to exclude from the comparison.</param>
+        /// <returns>The resulting comparison error message; <c>null</c> indicates equality.</returns>
+        public string? CompareValues(object? left, object? right, CoreEx.Json.IJsonSerializer jsonSerializer, params string[] pathsToIgnore)
+        {
+            if (jsonSerializer is null)
+                throw new ArgumentNullException(nameof(jsonSerializer));
+
+            return Compare(SerializeValue(jsonSerializer, left, nameof(left)), SerializeValue(jsonSerializer, right, nameof(right)), pathsToIgnore);
+        }
+
+        /// <summary>
+        /// Serialize the value to JSON.
+        /// </summary>
+        private static string SerializeValue(CoreEx.Json.IJsonSerializer jsonSerializer, object? value, string name)
+        {
+            if (value is JObject jo)
+                return jo.ToString(Newtonsoft.Json.Formatting.None);
+            else if (value is JsonElement je)
+                return je.ToString();
+
+            try
+            {
+                return jsonSerializer.Serialize(value);
+            }
+            catch (Exception ex)
+            {
+                throw new ArgumentException($"Failed to serialize value '{value?.GetType().FullName ?? "null"}' to JSON.", name, ex);
+            }
+        }
 
         /// <summary>
         /// Compare two JSON strings for equality.
@@ -339,7 +397,7 @@ namespace UnitTestEx.Abstractions
             public void Compare(string name, Action action)
             {
                 var path = Path == null ? name : $"{Path}.{name}";
-                if (PathsToIgnore.Contains(path, StringComparer.InvariantCultureIgnoreCase))
+                if (PathsToIgnore.Contains(path, PathComparer))
                     return;
 
                 _path.Push(path);

--- a/src/UnitTestEx/Abstractions/ObjectComparer.cs
+++ b/src/UnitTestEx/Abstractions/ObjectComparer.cs
@@ -8,6 +8,7 @@ namespace UnitTestEx.Abstractions
     /// <summary>
     /// Represents the object comparer using <see cref="CompareLogic"/> to perform.
     /// </summary>
+    [Obsolete($"This is being replaced by the {nameof(JsonElementComparer)} and usage of paths to ignore (versus members) to be more explicit.")]
     public static class ObjectComparer
     {
         private static Func<ComparisonConfig> _config = () => new ComparisonConfig

--- a/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
@@ -70,9 +70,6 @@ namespace UnitTestEx.AspNetCore
 
                             sc.ReplaceScoped(_ => SharedState);
                             SetUp.ConfigureServices?.Invoke(sc);
-                            if (SetUp.ExpectedEventsEnabled)
-                                ReplaceExpectedEventPublisher(sc);
-
                             AddConfiguredServices(sc);
                         }).ConfigureLogging(lb => { lb.SetMinimumLevel(SetUp.MinimumLogLevel); lb.ClearProviders(); lb.AddProvider(LoggerProvider); }));
             }

--- a/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
-using Azure.Core;
 using CoreEx.Http;
 using CoreEx.Json;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/UnitTestEx/Assertors/ActionResultAssertor.cs
+++ b/src/UnitTestEx/Assertors/ActionResultAssertor.cs
@@ -84,17 +84,17 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
         /// <param name="expectedValue">The expected value.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
         /// <remarks>The <see cref="Result"/> must be an <see cref="ObjectResult"/>, <see cref="JsonResult"/> or <see cref="ContentResult"/> or an assertion error will occur.</remarks>
-        public ActionResultAssertor Assert<TValue>(TValue expectedValue, params string[] membersToIgnore)
+        public ActionResultAssertor Assert<TValue>(TValue expectedValue, params string[] pathsToIgnore)
         {
             if (Result is ObjectResult)
-                return AssertObjectResult(expectedValue, membersToIgnore);
+                return AssertObjectResult(expectedValue, pathsToIgnore);
             else if (Result is JsonResult)
-                return AssertJsonResult(expectedValue, membersToIgnore);
+                return AssertJsonResult(expectedValue, pathsToIgnore);
             else if (Result is ContentResult)
-                return AssertContentResult(expectedValue, membersToIgnore);
+                return AssertContentResult(expectedValue, pathsToIgnore);
 
             Implementor.AssertFail($"Result IActionResult Type '{Result.GetType().Name}' must be either '{nameof(JsonResult)}', '{nameof(ObjectResult)}' or '{nameof(ContentResult)}' to assert its value.");
             return this;
@@ -105,10 +105,10 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
-        public ActionResultAssertor AssertFromJsonResource<TValue>(string resourceName, params string[] membersToIgnore)
-            => Assert(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), membersToIgnore);
+        public ActionResultAssertor AssertFromJsonResource<TValue>(string resourceName, params string[] pathsToIgnore)
+            => Assert(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), pathsToIgnore);
 
         /// <summary>
         /// Asserts that the <see cref="Result"/> has the specified <c>Content</c> matches the JSON serialized value.
@@ -116,10 +116,10 @@ namespace UnitTestEx.Assertors
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
-        public ActionResultAssertor AssertFromJsonResource<TAssembly, TValue>(string resourceName, params string[] membersToIgnore) 
-            => Assert(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), membersToIgnore);
+        public ActionResultAssertor AssertFromJsonResource<TAssembly, TValue>(string resourceName, params string[] pathsToIgnore) 
+            => Assert(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), pathsToIgnore);
 
         /// <summary>
         /// Asserts that the <see cref="Result"/> is an <see cref="HttpStatusCode.NotFound"/>.
@@ -309,14 +309,14 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
         /// <param name="expectedValue">The expected value.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
-        internal ActionResultAssertor AssertObjectResult<TValue>(TValue expectedValue, params string[] membersToIgnore)
+        internal ActionResultAssertor AssertObjectResult<TValue>(TValue expectedValue, params string[] pathsToIgnore)
         {
             AssertResultType<ObjectResult>();
 
             var or = (ObjectResult)Result;
-            return AssertValue(expectedValue, or.Value, membersToIgnore);
+            return AssertValue(expectedValue, or.Value, pathsToIgnore);
         }
 
         /// <summary>
@@ -324,14 +324,14 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
         /// <param name="expectedValue">The expected value.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
-        internal ActionResultAssertor AssertJsonResult<TValue>(TValue expectedValue, params string[] membersToIgnore)
+        internal ActionResultAssertor AssertJsonResult<TValue>(TValue expectedValue, params string[] pathsToIgnore)
         {
             AssertResultType<JsonResult>();
 
             var jr = (JsonResult)Result;
-            return AssertValue(expectedValue, jr.Value, membersToIgnore);
+            return AssertValue(expectedValue, jr.Value, pathsToIgnore);
         }
 
         /// <summary>
@@ -339,23 +339,23 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
         /// <param name="expectedValue">The expected value.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
-        internal ActionResultAssertor AssertContentResult<TValue>(TValue expectedValue, params string[] membersToIgnore)
+        internal ActionResultAssertor AssertContentResult<TValue>(TValue expectedValue, params string[] pathsToIgnore)
         {
             AssertResultType<ContentResult>();
 
             var cr = (ContentResult)Result;
             if (expectedValue != null && cr.Content != null && cr.ContentType == MediaTypeNames.Application.Json)
-                return AssertValue(expectedValue, JsonSerializer.Deserialize<TValue>(cr.Content)!, membersToIgnore);
+                return AssertValue(expectedValue, JsonSerializer.Deserialize<TValue>(cr.Content)!, pathsToIgnore);
             else
-                return AssertValue(expectedValue, cr.Content!, membersToIgnore);
+                return AssertValue(expectedValue, cr.Content!, pathsToIgnore);
         }
 
         /// <summary>
         /// Assert the value.
         /// </summary>
-        private ActionResultAssertor AssertValue<TValue>(TValue? expectedValue, object? actualValue, string[] membersToIgnore)
+        private ActionResultAssertor AssertValue<TValue>(TValue? expectedValue, object? actualValue, string[] pathsToIgnore)
         {
             if (expectedValue == null && actualValue == null)
                 return this;
@@ -364,9 +364,9 @@ namespace UnitTestEx.Assertors
                 Implementor.AssertAreEqual(expectedValue, actualValue);
             else
             {
-                var cr = ObjectComparer.Compare(expectedValue, actualValue, membersToIgnore);
-                if (!cr.AreEqual)
-                    Implementor.AssertFail($"Expected and Actual values are not equal: {cr.DifferencesString}");
+                var cr = JsonElementComparer.Default.CompareValues(expectedValue, actualValue, JsonSerializer, pathsToIgnore);
+                if (cr is not null)
+                    Implementor.AssertFail($"Expected and Actual values are not equal: {cr}");
             }
 
             return this;
@@ -407,7 +407,7 @@ namespace UnitTestEx.Assertors
             if (!JsonElement.TryParseValue(ref act, out JsonElement? aje))
                 Implementor.AssertFail("Actual value is not considered valid JSON.");
 
-            var jecr = new JsonElementComparer(5).Compare(eje!.Value, aje!.Value, pathsToIgnore);
+            var jecr = JsonElementComparer.Default.Compare(eje!.Value, aje!.Value, pathsToIgnore);
             if (jecr != null)
                 Implementor.AssertFail($"Expected and Actual JSON values are not equal:{Environment.NewLine}{jecr}");
 

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertor.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertor.cs
@@ -43,9 +43,9 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <typeparam name="TValue">The response value <see cref="Type"/>.</typeparam>
         /// <param name="expectedValue">The expected value.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertor"/> to support fluent-style method-chaining.</returns>
-        public HttpResponseMessageAssertor Assert<TValue>(TValue? expectedValue, params string[] membersToIgnore)
+        public HttpResponseMessageAssertor Assert<TValue>(TValue? expectedValue, params string[] pathsToIgnore)
         {
             if (Response.Content == null)
             {
@@ -65,9 +65,9 @@ namespace UnitTestEx.Assertors
                 }
 
                 var val = JsonSerializer.Deserialize<TValue>(json);
-                var cr = ObjectComparer.Compare(expectedValue, val, membersToIgnore);
-                if (!cr.AreEqual)
-                    Implementor.AssertFail($"Expected and Actual values are not equal: {cr.DifferencesString}");
+                var cr = JsonElementComparer.Default.CompareValues(expectedValue, val, JsonSerializer, pathsToIgnore);
+                if (cr is not null)
+                    Implementor.AssertFail($"Expected and Actual values are not equal: {cr}");
             }
             else
                 Implementor.AssertAreEqual(expectedValue?.ToString(), Response.Content.ReadAsStringAsync().GetAwaiter().GetResult(), "Expected and Actual values are not equal.");
@@ -80,9 +80,9 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <typeparam name="TValue">The response value <see cref="Type"/>.</typeparam>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertor"/> to support fluent-style method-chaining.</returns>
-        public HttpResponseMessageAssertor AssertFromJsonResource<TValue>(string resourceName, params string[] membersToIgnore) => Assert(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), membersToIgnore);
+        public HttpResponseMessageAssertor AssertFromJsonResource<TValue>(string resourceName, params string[] pathsToIgnore) => Assert(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), pathsToIgnore);
 
         /// <summary>
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> matches the JSON serialized value.
@@ -90,8 +90,8 @@ namespace UnitTestEx.Assertors
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
         /// <typeparam name="TValue">The response value <see cref="Type"/>.</typeparam>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertor"/> to support fluent-style method-chaining.</returns>
-        public HttpResponseMessageAssertor AssertFromJsonResource<TAssembly, TValue>(string resourceName, params string[] membersToIgnore) => Assert(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), membersToIgnore);
+        public HttpResponseMessageAssertor AssertFromJsonResource<TAssembly, TValue>(string resourceName, params string[] pathsToIgnore) => Assert(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), pathsToIgnore);
     }
 }

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
@@ -248,7 +248,7 @@ namespace UnitTestEx.Assertors
                 if (!JsonElement.TryParseValue(ref act, out JsonElement? aje))
                     Implementor.AssertFail("Actual value is not considered valid JSON.");
 
-                var jecr = new JsonElementComparer(5).Compare(eje!.Value, aje!.Value, pathsToIgnore);
+                var jecr = JsonElementComparer.Default.Compare(eje!.Value, aje!.Value, pathsToIgnore);
                 if (jecr != null)
                     Implementor.AssertFail($"Expected and Actual JSON values are not equal:{Environment.NewLine}{jecr}");
             }

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorT.cs
@@ -73,13 +73,13 @@ namespace UnitTestEx.Assertors
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> matches the <paramref name="expectedValue"/>.
         /// </summary>
         /// <param name="expectedValue">The expected value.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
-        public HttpResponseMessageAssertor<TValue> Assert(TValue? expectedValue, params string[] membersToIgnore)
+        public HttpResponseMessageAssertor<TValue> Assert(TValue? expectedValue, params string[] pathsToIgnore)
         {
-            var cr = ObjectComparer.Compare(expectedValue, Value, membersToIgnore);
-            if (!cr.AreEqual)
-                Implementor.AssertFail($"Expected and Actual values are not equal: {cr.DifferencesString}");
+            var cr = JsonElementComparer.Default.CompareValues(expectedValue, Value, JsonSerializer, pathsToIgnore);
+            if (cr is not null)
+                Implementor.AssertFail($"Expected and Actual values are not equal: {cr}");
 
             return this;
         }
@@ -88,17 +88,17 @@ namespace UnitTestEx.Assertors
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> matches the JSON serialized value.
         /// </summary>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
-        public HttpResponseMessageAssertor<TValue> AssertFromJsonResource(string resourceName, params string[] membersToIgnore) => Assert(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), membersToIgnore);
+        public HttpResponseMessageAssertor<TValue> AssertFromJsonResource(string resourceName, params string[] pathsToIgnore) => Assert(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), pathsToIgnore);
 
         /// <summary>
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> matches the JSON serialized value.
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
-        public HttpResponseMessageAssertor<TValue> AssertFromJsonResource<TAssembly>(string resourceName, params string[] membersToIgnore) => Assert(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), membersToIgnore);
+        public HttpResponseMessageAssertor<TValue> AssertFromJsonResource<TAssembly>(string resourceName, params string[] pathsToIgnore) => Assert(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), pathsToIgnore);
     }
 }

--- a/src/UnitTestEx/Assertors/ValueAssertor.cs
+++ b/src/UnitTestEx/Assertors/ValueAssertor.cs
@@ -33,18 +33,18 @@ namespace UnitTestEx.Assertors
         /// Asserts that the <see cref="Result"/> matches the <paramref name="expectedValue"/>.
         /// </summary>
         /// <param name="expectedValue">The expected value.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
-        public ValueAssertor<TValue> Assert(TValue expectedValue, params string[] membersToIgnore)
+        public ValueAssertor<TValue> Assert(TValue expectedValue, params string[] pathsToIgnore)
         {
             AssertSuccess();
             if (expectedValue is IComparable)
                 Implementor.AssertAreEqual(expectedValue, Result);
             else
             {
-                var cr = ObjectComparer.Compare(expectedValue, Result, membersToIgnore);
-                if (!cr.AreEqual)
-                    Implementor.AssertFail($"Expected and Actual values are not equal: {cr.DifferencesString}");
+                var cr = JsonElementComparer.Default.CompareValues(expectedValue, Result, JsonSerializer, pathsToIgnore);
+                if (cr is not null)
+                    Implementor.AssertFail($"Expected and Actual values are not equal: {cr}");
             }
 
             return this;
@@ -54,28 +54,28 @@ namespace UnitTestEx.Assertors
         ///  Asserts that the <see cref="Result"/> matches the <paramref name="json"/> serialized value.
         /// </summary>
         /// <param name="json">The JSON <see cref="string"/>.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
-        public ValueAssertor<TValue> AssertFromJson(string json, params string[] membersToIgnore) => Assert(JsonSerializer.Deserialize<TValue>(json)!, membersToIgnore);
+        public ValueAssertor<TValue> AssertFromJson(string json, params string[] pathsToIgnore) => Assert(JsonSerializer.Deserialize<TValue>(json)!, pathsToIgnore);
 
         /// <summary>
         /// Asserts that the <see cref="Result"/> matches the JSON serialized value from the named embedded resource.
         /// </summary>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
-        public ValueAssertor<TValue> AssertFromJsonResource(string resourceName, params string[] membersToIgnore)
-            => Assert(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), membersToIgnore);
+        public ValueAssertor<TValue> AssertFromJsonResource(string resourceName, params string[] pathsToIgnore)
+            => Assert(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), pathsToIgnore);
 
         /// <summary>
         /// Asserts that the <see cref="Result"/> matches the JSON serialized value from the named embedded resource.
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
-        public ValueAssertor<TValue> AssertFromJsonResource<TAssembly>(string resourceName, params string[] membersToIgnore)
-            => Assert(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), membersToIgnore);
+        public ValueAssertor<TValue> AssertFromJsonResource<TAssembly>(string resourceName, params string[] pathsToIgnore)
+            => Assert(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), pathsToIgnore);
 
         /// <summary>
         /// Converts the <see cref="ValueAssertor{TValue}"/> to an <see cref="ActionResultAssertor"/>.

--- a/src/UnitTestEx/Expectations/EventExpectations.cs
+++ b/src/UnitTestEx/Expectations/EventExpectations.cs
@@ -211,8 +211,7 @@ namespace UnitTestEx.Expectations
                 list.AddRange(new string[] { nameof(EventDataBase.Source), nameof(EventDataBase.Subject), nameof(EventDataBase.Action), nameof(EventDataBase.Type) });
                 list.AddRange(expectedEvents[i].PathsToIgnore);
 
-                var jec = new JsonElementComparer(5);
-                var res = jec.Compare(Tester.JsonSerializer.Serialize(exp), actualEvents[i]!, list.ToArray());
+                var res = JsonElementComparer.Default.Compare(Tester.JsonSerializer.Serialize(exp), actualEvents[i]!, list.ToArray());
                 if (res != null)
                     Implementor.AssertFail($"Destination {destination}: Expected event is not equal to actual: {res}");
             }

--- a/src/UnitTestEx/Expectations/ExpectationsExtensions.cs
+++ b/src/UnitTestEx/Expectations/ExpectationsExtensions.cs
@@ -8,8 +8,8 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Text;
-using UnitTestEx.Abstractions;
 using UnitTestEx.AspNetCore;
 
 namespace UnitTestEx.Expectations
@@ -155,28 +155,28 @@ namespace UnitTestEx.Expectations
             => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.SetExpectChangeLogUpdated(updatedBy, updatedDateGreaterThan));
 
         /// <summary>
-        /// Expect a response comparing the result of the specified <paramref name="expectedValueFunc"/> (and optionally any additional <paramref name="membersToIgnore"/> from the comparison).
+        /// Expect a response comparing the result of the specified <paramref name="expectedValueFunc"/> (and optionally any additional <paramref name="pathsToIgnore"/> from the comparison).
         /// </summary>
         /// <typeparam name="TValue">The response value <see cref="Type"/>.</typeparam>
         /// <typeparam name="TSelf">The tester <see cref="Type"/>.</typeparam>
         /// <param name="tester">The <see cref="IResponseValueExpectations{TValue, TSelf}"/>.</param>
         /// <param name="expectedValueFunc">The function to generate the response value to compare.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
-        public static TSelf ExpectValue<TValue, TSelf>(this IResponseValueExpectations<TValue, TSelf> tester, Func<TSelf, TValue> expectedValueFunc, params string[] membersToIgnore) where TSelf : IResponseValueExpectations<TValue, TSelf>
-            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.SetExpectValue(t => expectedValueFunc((TSelf)t), membersToIgnore));
+        public static TSelf ExpectValue<TValue, TSelf>(this IResponseValueExpectations<TValue, TSelf> tester, Func<TSelf, TValue> expectedValueFunc, params string[] pathsToIgnore) where TSelf : IResponseValueExpectations<TValue, TSelf>
+            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.SetExpectValue(t => expectedValueFunc((TSelf)t), pathsToIgnore));
 
         /// <summary>
-        /// Expect a response comparing the result of the specified <paramref name="expectedValue"/> (and optionally any additional <paramref name="membersToIgnore"/> from the comparison).
+        /// Expect a response comparing the result of the specified <paramref name="expectedValue"/> (and optionally any additional <paramref name="pathsToIgnore"/> from the comparison).
         /// </summary>
         /// <typeparam name="TValue">The response value <see cref="Type"/>.</typeparam>
         /// <typeparam name="TSelf">The tester <see cref="Type"/>.</typeparam>
         /// <param name="tester">The <see cref="IResponseValueExpectations{TValue, TSelf}"/>.</param>
         /// <param name="expectedValue">The expected response value to compare.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
-        public static TSelf ExpectValue<TValue, TSelf>(this IResponseValueExpectations<TValue, TSelf> tester, TValue expectedValue, params string[] membersToIgnore) where TSelf : IResponseValueExpectations<TValue, TSelf>
-            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.SetExpectValue(_ => expectedValue ?? throw new ArgumentNullException(nameof(expectedValue)), membersToIgnore));
+        public static TSelf ExpectValue<TValue, TSelf>(this IResponseValueExpectations<TValue, TSelf> tester, TValue expectedValue, params string[] pathsToIgnore) where TSelf : IResponseValueExpectations<TValue, TSelf>
+            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.SetExpectValue(_ => expectedValue ?? throw new ArgumentNullException(nameof(expectedValue)), pathsToIgnore));
 
         /// <summary>
         /// Ignores the <see cref="IChangeLog.ChangeLog"/> property.
@@ -270,10 +270,10 @@ namespace UnitTestEx.Expectations
         /// <param name="value">The expected <see cref="EventData.Value"/>.</param>
         /// <param name="subject">The expected subject (may contain wildcards).</param>
         /// <param name="action">The expected action (may contain wildcards).</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsMembersToIgnore"/>.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsPathsToIgnore"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
-        public static TSelf ExpectEventValue<TSelf>(this IEventExpectations<TSelf> tester, object? value, string subject, string? action, params string[] membersToIgnore) where TSelf : IEventExpectations<TSelf>
-            => tester.SetEventExpectation(t => t.EventExpectations.Expect(null, new EventData { Subject = subject, Action = action, Value = value }, membersToIgnore));
+        public static TSelf ExpectEventValue<TSelf>(this IEventExpectations<TSelf> tester, object? value, string subject, string? action, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => tester.SetEventExpectation(t => t.EventExpectations.Expect(null, new EventData { Subject = subject, Action = action, Value = value }, pathsToIgnore));
 
         /// <summary>
         /// Expects that the corresponding event has been published (in order specified). The expected event <paramref name="source"/>, <paramref name="subject"/> and <paramref name="action"/> can use wildcards. All other <see cref="EventData"/> 
@@ -294,11 +294,11 @@ namespace UnitTestEx.Expectations
         /// </summary>
         /// <param name="tester">The <see cref="IEventExpectations{TSelf}"/>.</param>
         /// <param name="event">The expected <paramref name="event"/>. Wildcards are supported for <see cref="EventDataBase.Subject"/> and <see cref="EventDataBase.Action"/>.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsMembersToIgnore"/>.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsPathsToIgnore"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         /// <remarks>Wildcards are supported for <see cref="EventDataBase.Subject"/>, <see cref="EventDataBase.Action"/> and <see cref="EventDataBase.Type"/>.</remarks>
-        public static TSelf ExpectEvent<TSelf>(this IEventExpectations<TSelf> tester, EventData @event, params string[] membersToIgnore) where TSelf : IEventExpectations<TSelf>
-            => tester.SetEventExpectation(t => t.EventExpectations.Expect(null, @event, membersToIgnore));
+        public static TSelf ExpectEvent<TSelf>(this IEventExpectations<TSelf> tester, EventData @event, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => tester.SetEventExpectation(t => t.EventExpectations.Expect(null, @event, pathsToIgnore));
 
         /// <summary>
         /// Expects that the corresponding <paramref name="event"/> has been published (in order specified). All properties for expected event will be compared again the actual.
@@ -306,11 +306,32 @@ namespace UnitTestEx.Expectations
         /// <param name="tester">The <see cref="IEventExpectations{TSelf}"/>.</param>
         /// <param name="source">The expected source formatted as a <see cref="Uri"/> (may contain wildcards).</param>
         /// <param name="event">The expected <paramref name="event"/>. Wildcards are supported for <see cref="EventDataBase.Subject"/> and <see cref="EventDataBase.Action"/>.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsMembersToIgnore"/>.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsPathsToIgnore"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         /// <remarks>Wildcards are supported for <see cref="EventDataBase.Subject"/>, <see cref="EventDataBase.Action"/> and <see cref="EventDataBase.Type"/>.</remarks>
-        public static TSelf ExpectEvent<TSelf>(this IEventExpectations<TSelf> tester, string source, EventData @event, params string[] membersToIgnore) where TSelf : IEventExpectations<TSelf>
-            => tester.SetEventExpectation(t => t.EventExpectations.Expect(null, source, @event, membersToIgnore));
+        public static TSelf ExpectEvent<TSelf>(this IEventExpectations<TSelf> tester, string source, EventData @event, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => tester.SetEventExpectation(t => t.EventExpectations.Expect(null, source, @event, pathsToIgnore));
+
+        /// <summary>
+        /// Expects that the JSON serialized <see cref="EventData"/> from the named embedded resource has been published (in order specified). All properties for expected event will be compared again the actual.
+        /// </summary>
+        /// <param name="tester">The <see cref="IEventExpectations{TSelf}"/>.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison.</param>
+        /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
+        public static TSelf ExpectEventFromJsonResource<TSelf>(this IEventExpectations<TSelf> tester, string resourceName, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => ExpectEventFromJsonResource(tester, resourceName, Assembly.GetCallingAssembly(), pathsToIgnore);
+
+        /// <summary>
+        /// Expects that the JSON serialized <see cref="EventData"/> from the named embedded resource has been published (in order specified). All properties for expected event will be compared again the actual.
+        /// </summary>
+        /// <param name="tester">The <see cref="IEventExpectations{TSelf}"/>.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison.</param>
+        /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
+        public static TSelf ExpectEventFromJsonResource<TSelf>(this IEventExpectations<TSelf> tester, string resourceName, Assembly assembly, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => tester.SetEventExpectation(t => t.EventExpectations.Expect(null, Resource.GetJsonValue<EventData>(resourceName, assembly ?? Assembly.GetCallingAssembly(), t.EventExpectations.Tester.JsonSerializer), pathsToIgnore));
 
         /// <summary>
         /// Expects that the corresponding <paramref name="destination"/> event has been published (in order specified). The expected event <paramref name="subject"/> and <paramref name="action"/> can use wildcards. All other <see cref="EventData"/> properties are not matched/verified.
@@ -333,10 +354,10 @@ namespace UnitTestEx.Expectations
         /// <param name="value">The expected <see cref="EventData.Value"/>.</param>
         /// <param name="subject">The expected subject (may contain wildcards).</param>
         /// <param name="action">The expected action (may contain wildcards).</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsMembersToIgnore"/>.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsPathsToIgnore"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
-        public static TSelf ExpectDestinationEventValue<TSelf>(this IEventExpectations<TSelf> tester, object? value, string destination, string subject, string? action, params string[] membersToIgnore) where TSelf : IEventExpectations<TSelf>
-            => tester.SetEventExpectation(t => t.EventExpectations.Expect(destination, new EventData { Subject = subject, Action = action, Value = value }, membersToIgnore));
+        public static TSelf ExpectDestinationEventValue<TSelf>(this IEventExpectations<TSelf> tester, object? value, string destination, string subject, string? action, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => tester.SetEventExpectation(t => t.EventExpectations.Expect(destination, new EventData { Subject = subject, Action = action, Value = value }, pathsToIgnore));
 
         /// <summary>
         /// Expects that the corresponding <paramref name="destination"/> event has been published (in order specified). The expected event <paramref name="source"/>, <paramref name="subject"/> and <paramref name="action"/> can use wildcards. All other <see cref="EventData"/> 
@@ -359,11 +380,11 @@ namespace UnitTestEx.Expectations
         /// <param name="tester">The <see cref="IEventExpectations{TSelf}"/>.</param>
         /// <param name="destination">The named destination (e.g. queue or topic).</param>
         /// <param name="event">The expected <paramref name="event"/>. Wildcards are supported for <see cref="EventDataBase.Subject"/> and <see cref="EventDataBase.Action"/>.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsMembersToIgnore"/>.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsPathsToIgnore"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         /// <remarks>Wildcards are supported for <see cref="EventDataBase.Subject"/>, <see cref="EventDataBase.Action"/> and <see cref="EventDataBase.Type"/>.</remarks>
-        public static TSelf ExpectDestinationEvent<TSelf>(this IEventExpectations<TSelf> tester, string destination, EventData @event, params string[] membersToIgnore) where TSelf : IEventExpectations<TSelf>
-            => tester.SetEventExpectation(t => t.EventExpectations.Expect(destination, @event, membersToIgnore));
+        public static TSelf ExpectDestinationEvent<TSelf>(this IEventExpectations<TSelf> tester, string destination, EventData @event, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => tester.SetEventExpectation(t => t.EventExpectations.Expect(destination, @event, pathsToIgnore));
 
         /// <summary>
         /// Expects that the corresponding <paramref name="destination"/> <paramref name="event"/> has been published (in order specified). All properties for expected event will be compared again the actual.
@@ -372,11 +393,34 @@ namespace UnitTestEx.Expectations
         /// <param name="destination">The named destination (e.g. queue or topic).</param>
         /// <param name="source">The expected source formatted as a <see cref="Uri"/> (may contain wildcards).</param>
         /// <param name="event">The expected <paramref name="event"/>. Wildcards are supported for <see cref="EventDataBase.Subject"/> and <see cref="EventDataBase.Action"/>.</param>
-        /// <param name="membersToIgnore">The members to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsMembersToIgnore"/>.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison. Defaults to <see cref="TestSetUp.ExpectedEventsPathsToIgnore"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         /// <remarks>Wildcards are supported for <see cref="EventDataBase.Subject"/>, <see cref="EventDataBase.Action"/> and <see cref="EventDataBase.Type"/>.</remarks>
-        public static TSelf ExpectDestinationEvent<TSelf>(this IEventExpectations<TSelf> tester, string destination, string source, EventData @event, params string[] membersToIgnore) where TSelf : IEventExpectations<TSelf>
-            => tester.SetEventExpectation(t => t.EventExpectations.Expect(destination, source, @event, membersToIgnore));
+        public static TSelf ExpectDestinationEvent<TSelf>(this IEventExpectations<TSelf> tester, string destination, string source, EventData @event, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => tester.SetEventExpectation(t => t.EventExpectations.Expect(destination, source, @event, pathsToIgnore));
+
+        /// <summary>
+        /// Expects that the JSON serialized <see cref="EventData"/> from the named embedded resource has been published (in order specified). All properties for expected event will be compared again the actual.
+        /// </summary>
+        /// <param name="tester">The <see cref="IEventExpectations{TSelf}"/>.</param>
+        /// <param name="destination">The named destination (e.g. queue or topic).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison.</param>
+        /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
+        public static TSelf ExpectDestinationEventFromJsonResource<TSelf>(this IEventExpectations<TSelf> tester, string destination, string resourceName, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => ExpectDestinationEventFromJsonResource(tester, destination, resourceName, Assembly.GetCallingAssembly(), pathsToIgnore);
+
+        /// <summary>
+        /// Expects that the JSON serialized <see cref="EventData"/> from the named embedded resource has been published (in order specified). All properties for expected event will be compared again the actual.
+        /// </summary>
+        /// <param name="tester">The <see cref="IEventExpectations{TSelf}"/>.</param>
+        /// <param name="destination">The named destination (e.g. queue or topic).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource.</param>
+        /// <param name="pathsToIgnore">The paths to ignore from the comparison.</param>
+        /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
+        public static TSelf ExpectDestinationEventFromJsonResource<TSelf>(this IEventExpectations<TSelf> tester, string destination, string resourceName, Assembly assembly, params string[] pathsToIgnore) where TSelf : IEventExpectations<TSelf>
+            => tester.SetEventExpectation(t => t.EventExpectations.Expect(destination, Resource.GetJsonValue<EventData>(resourceName, assembly ?? Assembly.GetCallingAssembly(), t.EventExpectations.Tester.JsonSerializer), pathsToIgnore));
 
         #endregion
 

--- a/src/UnitTestEx/Expectations/ExpectationsExtensions.cs
+++ b/src/UnitTestEx/Expectations/ExpectationsExtensions.cs
@@ -186,7 +186,7 @@ namespace UnitTestEx.Expectations
         /// <param name="tester">The <see cref="IResponseValueExpectations{TValue, TSelf}"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         public static TSelf IgnoreChangeLog<TValue, TSelf>(this IResponseValueExpectations<TValue, TSelf> tester) where TSelf : IResponseValueExpectations<TValue, TSelf>
-            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.MembersToIgnore.Add(nameof(IChangeLog.ChangeLog)));
+            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.PathsToIgnore.Add(nameof(IChangeLog.ChangeLog)));
 
         /// <summary>
         /// Ignores the <see cref="IETag.ETag"/> property.
@@ -196,7 +196,7 @@ namespace UnitTestEx.Expectations
         /// <param name="tester">The <see cref="IResponseValueExpectations{TValue, TSelf}"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         public static TSelf IgnoreETag<TValue, TSelf>(this IResponseValueExpectations<TValue, TSelf> tester) where TSelf : IResponseValueExpectations<TValue, TSelf>
-            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.MembersToIgnore.Add(nameof(IETag.ETag)));
+            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.PathsToIgnore.Add(nameof(IETag.ETag)));
 
         /// <summary>
         /// Ignores the <see cref="IPrimaryKey.PrimaryKey"/> property.
@@ -206,7 +206,7 @@ namespace UnitTestEx.Expectations
         /// <param name="tester">The <see cref="IResponseValueExpectations{TValue, TSelf}"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         public static TSelf IgnorePrimaryKey<TValue, TSelf>(this IResponseValueExpectations<TValue, TSelf> tester) where TSelf : IResponseValueExpectations<TValue, TSelf>
-            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.MembersToIgnore.Add(nameof(IPrimaryKey.PrimaryKey)));
+            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.PathsToIgnore.Add(nameof(IPrimaryKey.PrimaryKey)));
 
         /// <summary>
         /// Ignores the <see cref="IIdentifier.Id"/> property.
@@ -216,7 +216,7 @@ namespace UnitTestEx.Expectations
         /// <param name="tester">The <see cref="IResponseValueExpectations{TValue, TSelf}"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         public static TSelf IgnoreId<TValue, TSelf>(this IResponseValueExpectations<TValue, TSelf> tester) where TSelf : IResponseValueExpectations<TValue, TSelf>
-            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.MembersToIgnore.Add(nameof(IIdentifier.Id)));
+            => tester.SetResponseValueExpectation(t => t.ResponseValueExpectations.PathsToIgnore.Add(nameof(IIdentifier.Id)));
 
         #endregion
 

--- a/src/UnitTestEx/Functions/FunctionTesterBase.cs
+++ b/src/UnitTestEx/Functions/FunctionTesterBase.cs
@@ -1,17 +1,11 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
-using Azure.Core.Amqp;
-using Azure.Messaging.ServiceBus;
 using CoreEx.AspNetCore.Http;
-using CoreEx.Azure.ServiceBus;
 using CoreEx.Configuration;
-using CoreEx.Events;
 using CoreEx.Hosting;
 using CoreEx.Http;
-using CoreEx.Mapping.Converters;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
-using Microsoft.Azure.WebJobs.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -26,7 +20,6 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
-using System.Web;
 using UnitTestEx.Abstractions;
 using UnitTestEx.Hosting;
 using Ceh = CoreEx.Http;
@@ -166,7 +159,7 @@ namespace UnitTestEx.Functions
                             .AddInMemoryCollection(new KeyValuePair<string, string?>[] { new KeyValuePair<string, string?>("AzureWebJobsConfigurationSection", "AzureFunctionsJobHost") })
                             .AddJsonFile(GetLocalSettingsJson(), optional: true)
                             .AddJsonFile("appsettings.json", optional: true)
-                            .AddJsonFile("appsettings.development.json", optional: true);
+                            .AddJsonFile($"appsettings.{TestSetUp.Environment.ToLowerInvariant()}.json", optional: true);
 
                         if ((!_includeUserSecrets.HasValue && TestSetUp.FunctionTesterIncludeUserSecrets) || (_includeUserSecrets.HasValue && _includeUserSecrets.Value))
                             cb.AddUserSecrets<TEntryPoint>();
@@ -193,9 +186,6 @@ namespace UnitTestEx.Functions
                         ep3?.ConfigureServices(sc);
                         sc.ReplaceScoped(_ => SharedState);
                         SetUp.ConfigureServices?.Invoke(sc);
-                        if (SetUp.ExpectedEventsEnabled)
-                            ReplaceExpectedEventPublisher(sc);
-
                         AddConfiguredServices(sc);
                     }).Build();
             }
@@ -419,143 +409,6 @@ namespace UnitTestEx.Functions
             hr.ContentType = MediaTypeNames.Application.Json;
             return hr;
         }
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> where the <see cref="ServiceBusMessage.Body"/> <see cref="BinaryData"/> will contain the <paramref name="value"/> as serialized JSON.
-        /// </summary>
-        /// <typeparam name="T">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
-        /// <param name="value">The value.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessage<T>(T value) => (value is EventData ed) ? CreateServiceBusMessage(ed) : CreateServiceBusMessageFromJson(JsonSerializer.Serialize(value));
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> where the <see cref="ServiceBusMessage.Body"/> <see cref="BinaryData"/> will contain the <paramref name="value"/> as serialized JSON.
-        /// </summary>
-        /// <typeparam name="T">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
-        /// <param name="value">The value.</param>
-        /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessage<T>(T value, Action<AmqpAnnotatedMessage>? messageModify = null)
-            => CreateServiceBusMessageFromJson(JsonSerializer.Serialize(value), messageModify);
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> where the <see cref="ServiceBusMessage.Body"/> <see cref="BinaryData"/> will contain the JSON formatted embedded resource as the content (<see cref="MediaTypeNames.Application.Json"/>).
-        /// </summary>
-        /// <typeparam name="TAssembly">The <see cref="Type"/> to infer <see cref="Type.Assembly"/> for the embedded resources.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
-        /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessageFromResource<TAssembly>(string resourceName, Action<AmqpAnnotatedMessage>? messageModify = null)
-            => CreateServiceBusMessageFromResource(resourceName, messageModify, typeof(TAssembly).Assembly);
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> where the <see cref="ServiceBusMessage.Body"/> <see cref="BinaryData"/> will contain the JSON formatted embedded resource as the content (<see cref="MediaTypeNames.Application.Json"/>).
-        /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
-        /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
-        /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetEntryAssembly()"/>.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessageFromResource(string resourceName, Action<AmqpAnnotatedMessage>? messageModify = null, Assembly? assembly = null)
-            => CreateServiceBusMessageFromJson(Resource.GetJson(resourceName, assembly ?? Assembly.GetCallingAssembly()), messageModify);
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> where the <see cref="ServiceBusMessage.Body"/> <see cref="BinaryData"/> will contain the serialized <paramref name="json"/>.
-        /// </summary>
-        /// <param name="json">The JSON body.</param>
-        /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessageFromJson(string json, Action<AmqpAnnotatedMessage>? messageModify = null)
-        {
-            var message = new AmqpAnnotatedMessage(AmqpMessageBody.FromData(new ReadOnlyMemory<byte>[] { Encoding.UTF8.GetBytes(json ?? throw new ArgumentNullException(nameof(json))) }));
-            message.Properties.ContentType = MediaTypeNames.Application.Json;
-            message.Properties.MessageId = new AmqpMessageId(Guid.NewGuid().ToString());
-            return CreateServiceBusMessage(message, messageModify);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> from the <paramref name="event"/> leveraging the <see cref="EventDataToServiceBusConverter"/> to perform the underlying conversion.
-        /// </summary>
-        /// <param name="event">The <see cref="EventData"/> or <see cref="EventData{T}"/> value.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        /// <remarks>Attempts to use the configured <see cref="EventDataToServiceBusConverter"/> by leveraging the underlying host <see cref="FunctionTesterBase{TEntryPoint, TSelf}.Services"/> where found; otherwise, will instantiate as new. As accessing
-        /// the <see cref="FunctionTesterBase{TEntryPoint, TSelf}.Services"/> will result in the underlying host being instantiated a corresponding <see cref="ResetHost"/> will be performed to enable further configuration.</remarks>
-        public ServiceBusReceivedMessage CreateServiceBusMessage(EventData @event) => CreateServiceBusMessage(@event, null);
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> from the <paramref name="event"/> leveraging the <see cref="EventDataToServiceBusConverter"/> to perform the underlying conversion.
-        /// </summary>
-        /// <param name="event">The <see cref="EventData"/> or <see cref="EventData{T}"/> value.</param>
-        /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        /// <remarks>Attempts to use the configured <see cref="EventDataToServiceBusConverter"/> by leveraging the underlying host <see cref="FunctionTesterBase{TEntryPoint, TSelf}.Services"/> where found; otherwise, will instantiate as new. As accessing
-        /// the <see cref="FunctionTesterBase{TEntryPoint, TSelf}.Services"/> will result in the underlying host being instantiated a corresponding <see cref="ResetHost"/> will be performed to enable further configuration.</remarks>
-        public ServiceBusReceivedMessage CreateServiceBusMessage(EventData @event, Action<AmqpAnnotatedMessage>? messageModify)
-        {
-            if (@event == null) throw new ArgumentNullException(nameof(@event));
-            var message = (Services.GetService<EventDataToServiceBusConverter>() ?? new EventDataToServiceBusConverter(Services.GetService<IEventSerializer>(), Services.GetService<IValueConverter<EventSendData, ServiceBusMessage>>())).Convert(@event).GetRawAmqpMessage();
-            ResetHost(false);
-            return CreateServiceBusMessage(message, messageModify);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> from the <paramref name="message"/>.
-        /// </summary>
-        /// <param name="message">The <see cref="ServiceBusMessage"/>.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessage(ServiceBusMessage message)
-            => CreateServiceBusMessage((message ?? throw new ArgumentNullException(nameof(message))).GetRawAmqpMessage(), null);
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> from the <paramref name="message"/>.
-        /// </summary>
-        /// <param name="message">The <see cref="ServiceBusMessage"/>.</param>
-        /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessage(ServiceBusMessage message, Action<AmqpAnnotatedMessage>? messageModify)
-            => CreateServiceBusMessage((message ?? throw new ArgumentNullException(nameof(message))).GetRawAmqpMessage(), messageModify);
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> from the <paramref name="message"/>.
-        /// </summary>
-        /// <param name="message">The <see cref="AmqpAnnotatedMessage"/>.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessage(AmqpAnnotatedMessage message) => CreateServiceBusMessage(message, null);
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusReceivedMessage"/> from the <paramref name="message"/>.
-        /// </summary>
-        /// <param name="message">The <see cref="AmqpAnnotatedMessage"/>.</param>
-        /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
-        /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
-        public ServiceBusReceivedMessage CreateServiceBusMessage(AmqpAnnotatedMessage message, Action<AmqpAnnotatedMessage>? messageModify)
-        {
-            message.Header.DeliveryCount ??= 1;
-            message.Header.Durable ??= true;
-            message.Header.Priority ??= 1;
-            message.Header.TimeToLive ??= TimeSpan.FromSeconds(60);
-
-            messageModify?.Invoke(message);
-
-            var t = typeof(ServiceBusReceivedMessage);
-            var c = t.GetConstructor(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance, null, new Type[] { typeof(AmqpAnnotatedMessage) }, null);
-            return c == null
-                ? throw new InvalidOperationException($"'{typeof(ServiceBusReceivedMessage).Name}' constructor that accepts Type '{typeof(AmqpAnnotatedMessage).Name}' parameter was not found.")
-                : (ServiceBusReceivedMessage)c.Invoke(new object?[] { message });
-        }
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusMessageActionsAssertor"/> as the <see cref="ServiceBusMessageActions"/> instance to enable test mock and assert verification.
-        /// </summary>
-        /// <returns>The <see cref="ServiceBusMessageActionsAssertor"/>.</returns>
-        public ServiceBusMessageActionsAssertor CreateServiceBusMessageActions() => new(Implementor);
-
-        /// <summary>
-        /// Creates a <see cref="ServiceBusSessionMessageActionsAssertor"/> as the <see cref="ServiceBusSessionMessageActions"/> instance to enable test mock and assert verification.
-        /// </summary>
-        /// <param name="sessionLockedUntil">The sessions locked until <see cref="DateTimeOffset"/>; defaults to <see cref="DateTimeOffset.UtcNow"/> plus five minutes.</param>
-        /// <param name="sessionState">The session state <see cref="BinaryData"/>; defaults to <see cref="BinaryData.Empty"/>.</param>
-        /// <returns>The <see cref="ServiceBusSessionMessageActionsAssertor"/>.</returns>
-        public ServiceBusSessionMessageActionsAssertor CreateServiceBusSessionMessageActions(DateTimeOffset? sessionLockedUntil = default, BinaryData? sessionState = default) => new(Implementor, sessionLockedUntil, sessionState);
 
         /// <summary>
         /// Releases all resources.

--- a/src/UnitTestEx/Generic/GenericTesterBase.cs
+++ b/src/UnitTestEx/Generic/GenericTesterBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
 using CoreEx;
+using CoreEx.Hosting;
+using Microsoft.Azure.Amqp.Framing;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
@@ -13,12 +15,14 @@ namespace UnitTestEx.Generic
     /// <summary>
     /// Provides generic testing capabilities.
     /// </summary>
-    public abstract class GenericTesterBase<TSelf> : GenericTesterCore<GenericTesterBase<TSelf>>
+    /// <typeparam name="TEntryPoint">The <see cref="IHostStartup"/> <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TSelf">The <see cref="GenericTesterBase{TEntryPoint, TSelf}"/> to support inheriting fluent-style method-chaining.</typeparam>
+    public abstract class GenericTesterBase<TEntryPoint, TSelf> : GenericTesterCore<TEntryPoint, GenericTesterBase<TEntryPoint, TSelf>> where TEntryPoint : IHostStartup, new() where TSelf : GenericTesterBase<TEntryPoint, TSelf>
     {
         private OperationType _operationType = CoreEx.OperationType.Unspecified;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="GenericTesterBase{TSelf}"/> class.
+        /// Initializes a new instance of the <see cref="GenericTesterBase{TEntryPoint, TSelf}"/> class.
         /// </summary>
         /// <param name="implementor">The <see cref="TestFrameworkImplementor"/>.</param>
         protected GenericTesterBase(TestFrameworkImplementor implementor) : base(implementor) { }
@@ -27,17 +31,17 @@ namespace UnitTestEx.Generic
         /// Sets the <see cref="ExecutionContext.OperationType"/> to the specified <paramref name="operationType"/>.
         /// </summary>
         /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <returns>The <see cref="GenericTesterBase{TSelf}"/> instance to support fluent/chaining usage.</returns>
-        public GenericTesterBase<TSelf> OperationType(OperationType operationType)
+        /// <returns>The <see cref="GenericTesterBase{TEntryPoint, TSelf}"/> instance to support fluent/chaining usage.</returns>
+        public TSelf OperationType(OperationType operationType)
         {
             _operationType = operationType;
-            return this;
+            return (TSelf)this;
         }
 
         /// <summary>
-        /// Executes the <paramref name="action"/> that performs the validation.
+        /// Executes the <paramref name="action"/> that performs the logic.
         /// </summary>
-        /// <param name="action">The function performing the validation.</param>
+        /// <param name="action">The function performing the logic.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
         public VoidAssertor Run(Action action) => RunAsync(() =>
         {
@@ -46,16 +50,53 @@ namespace UnitTestEx.Generic
         }).GetAwaiter().GetResult();
 
         /// <summary>
-        /// Executes the <paramref name="function"/> that performs the validation.
+        /// Executes the <paramref name="action"/> that performs the logic.
         /// </summary>
-        /// <param name="function">The function performing the validation.</param>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="action">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        public VoidAssertor Run<TService>(Action<TService> action) where TService : class => RunAsync(() =>
+        {
+            var service = Services.GetRequiredService<TService>();
+            (action ?? throw new ArgumentNullException(nameof(action))).Invoke(service);
+            return Task.CompletedTask;
+        }).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic.
+        /// </summary>
+        /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
         public VoidAssertor Run(Func<Task> function) => RunAsync(function).GetAwaiter().GetResult();
 
         /// <summary>
-        /// Executes the <paramref name="function"/> that performs the validation.
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
         /// </summary>
-        /// <param name="function">The function performing the validation.</param>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        public VoidAssertor Run<TService>(Func<TService, Task> function) where TService : class
+        {
+            var service = Services.GetRequiredService<TService>();
+            return RunAsync(() => function(service)).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        public Task<VoidAssertor> RunAsync<TService>(Func<TService, Task> function) where TService : class
+        {
+            var service = Services.GetRequiredService<TService>();
+            return RunAsync(() => function(service));
+        }
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic.
+        /// </summary>
+        /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
         public async Task<VoidAssertor> RunAsync(Func<Task> function)
         {
@@ -65,16 +106,13 @@ namespace UnitTestEx.Generic
             TestSetUp.LogAutoSetUpOutputs(Implementor);
 
             Implementor.WriteLine("");
-            Implementor.WriteLine("VALIDATION TESTER...");
+            Implementor.WriteLine("GENERIC TESTER...");
             Implementor.WriteLine("");
 
             var ec = Services.GetRequiredService<ExecutionContext>();
             ec.OperationType = _operationType;
 
             Exception? exception = null;
-
-            Implementor.WriteLine("VALIDATE >");
-            Implementor.WriteLine("Validator: <function>");
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
 
@@ -93,7 +131,6 @@ namespace UnitTestEx.Generic
 
             sw.Stop();
 
-            Implementor.WriteLine("");
             Implementor.WriteLine("LOGGING >");
             var messages = SharedState.GetLoggerMessages();
             if (messages.Any())
@@ -122,33 +159,78 @@ namespace UnitTestEx.Generic
             Implementor.WriteLine("");
 
             ExceptionSuccessExpectations.Assert(exception);
+            EventExpectations.Assert();
+            LoggerExpectations.Assert(messages);
             return new VoidAssertor(exception, Implementor, JsonSerializer);
         }
 
         /// <summary>
-        /// Executes the <paramref name="function"/> that performs the validation.
+        /// Executes the <paramref name="function"/> that performs the logic.
         /// </summary>
-        /// <param name="function">The function performing the validation.</param>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
-        public ValueAssertor<T> Run<T>(Func<T> function) => RunAsync(() =>
+        public ValueAssertor<TValue> Run<TValue>(Func<TValue> function) => RunAsync(() =>
         {
-            T value = (function ?? throw new ArgumentNullException(nameof(function))).Invoke();
+            TValue value = (function ?? throw new ArgumentNullException(nameof(function))).Invoke();
             return Task.FromResult(value);
         }).GetAwaiter().GetResult();
 
         /// <summary>
-        /// Executes the <paramref name="function"/> that performs the validation.
+        /// Executes the <paramref name="function"/> that performs the logic.
         /// </summary>
-        /// <param name="function">The function performing the validation.</param>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
-        public ValueAssertor<T> Run<T>(Func<Task<T>> function) => RunAsync(function).GetAwaiter().GetResult();
+        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, TValue> function) where TService : class => RunAsync(() =>
+        {
+            var service = Services.GetRequiredService<TService>();
+            TValue value = (function ?? throw new ArgumentNullException(nameof(function))).Invoke(service);
+            return Task.FromResult(value);
+        }).GetAwaiter().GetResult();
 
         /// <summary>
-        /// Executes the <paramref name="function"/> that performs the validation.
+        /// Executes the <paramref name="function"/> that performs the logic.
         /// </summary>
-        /// <param name="function">The function performing the validation.</param>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
-        public async Task<ValueAssertor<T>> RunAsync<T>(Func<Task<T>> function)
+        public ValueAssertor<TValue> Run<TValue>(Func<Task<TValue>> function) => RunAsync(function).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, Task<TValue>> function) where TService : class
+        {
+            var service = Services.GetRequiredService<TService>();
+            return RunAsync(() => function(service)).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        public Task<ValueAssertor<TValue>> RunAsync<TService, TValue>(Func<TService, Task<TValue>> function) where TService : class
+        {
+            var service = Services.GetRequiredService<TService>();
+            return RunAsync(() => function(service));
+        }
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic.
+        /// </summary>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
+        public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<Task<TValue>> function)
         {
             if (function == null)
                 throw new ArgumentNullException(nameof(function));
@@ -156,7 +238,7 @@ namespace UnitTestEx.Generic
             TestSetUp.LogAutoSetUpOutputs(Implementor);
 
             Implementor.WriteLine("");
-            Implementor.WriteLine("VALIDATION TESTER...");
+            Implementor.WriteLine("GENERIC TESTER...");
             Implementor.WriteLine("");
 
             var ec = Services.GetRequiredService<ExecutionContext>();
@@ -164,13 +246,8 @@ namespace UnitTestEx.Generic
 
             Exception? exception = null;
 
-            Implementor.WriteLine("VALIDATE >");
-            Implementor.WriteLine("Validator: <function>");
-            Implementor.WriteLine("");
-            Implementor.WriteLine("LOGGING >");
-
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            T value = default!;
+            TValue value = default!;
 
             try
             {
@@ -187,6 +264,18 @@ namespace UnitTestEx.Generic
 
             sw.Stop();
 
+            Implementor.WriteLine("LOGGING >");
+            var messages = SharedState.GetLoggerMessages();
+            if (messages.Any())
+            {
+                foreach (var msg in messages)
+                {
+                    Implementor.WriteLine(msg);
+                }
+            }
+            else
+                Implementor.WriteLine("None.");
+
             Implementor.WriteLine("");
             Implementor.WriteLine("RESULT >");
             Implementor.WriteLine($"Elapsed (ms): {sw.Elapsed.TotalMilliseconds}");
@@ -196,14 +285,26 @@ namespace UnitTestEx.Generic
                 Implementor.WriteLine(exception.ToString());
             }
             else
+            {
                 Implementor.WriteLine($"Result: Success");
+                try
+                {
+                    Implementor.WriteLine($"Value: {JsonSerializer.Serialize(value, CoreEx.Json.JsonWriteFormat.Indented)}");
+                }
+                catch (Exception ex)
+                {
+                    Implementor.WriteLine($"Value serialization error: {ex.Message}");
+                }
+            }
 
             Implementor.WriteLine("");
             Implementor.WriteLine(new string('=', 80));
             Implementor.WriteLine("");
 
             ExceptionSuccessExpectations.Assert(exception);
-            return new ValueAssertor<T>(value, exception, Implementor, JsonSerializer);
+            EventExpectations.Assert();
+            LoggerExpectations.Assert(messages);
+            return new ValueAssertor<TValue>(value, exception, Implementor, JsonSerializer);
         }
     }
 }

--- a/src/UnitTestEx/Generic/ValidationTesterBase.cs
+++ b/src/UnitTestEx/Generic/ValidationTesterBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
 using CoreEx;
+using CoreEx.Hosting;
 using CoreEx.Validation;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -14,12 +15,14 @@ namespace UnitTestEx.Generic
     /// <summary>
     /// Provides the <see cref="IValidator"/> testing capabilities.
     /// </summary>
-    public abstract class ValidationTesterBase<TSelf> : GenericTesterCore<ValidationTesterBase<TSelf>>
+    /// <typeparam name="TEntryPoint">The <see cref="IHostStartup"/> <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TSelf">The <see cref="ValidationTesterBase{TEntryPoint, TSelf}"/> to support inheriting fluent-style method-chaining.</typeparam>
+    public abstract class ValidationTesterBase<TEntryPoint, TSelf> : GenericTesterCore<TEntryPoint, ValidationTesterBase<TEntryPoint, TSelf>> where TEntryPoint : IHostStartup, new() where TSelf : ValidationTesterBase<TEntryPoint, TSelf>
     {
         private OperationType _operationType = CoreEx.OperationType.Unspecified;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationTesterBase{TSelf}"/> class.
+        /// Initializes a new instance of the <see cref="ValidationTesterBase{TEntryPoint, TSelf}"/> class.
         /// </summary>
         /// <param name="implementor">The <see cref="TestFrameworkImplementor"/>.</param>
         protected ValidationTesterBase(TestFrameworkImplementor implementor) : base(implementor) { }
@@ -28,11 +31,11 @@ namespace UnitTestEx.Generic
         /// Sets the <see cref="ExecutionContext.OperationType"/> to the specified <paramref name="operationType"/>.
         /// </summary>
         /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <returns>The <see cref="ValidationTesterBase{TSelf}"/> instance to support fluent/chaining usage.</returns>
-        public ValidationTesterBase<TSelf> OperationType(OperationType operationType)
+        /// <returns>The <see cref="ValidationTesterBase{TEntryPoint, TSelf}"/> instance to support fluent/chaining usage.</returns>
+        public TSelf OperationType(OperationType operationType)
         {
             _operationType = operationType;
-            return this;
+            return (TSelf)this;
         }
 
         /// <summary>
@@ -167,6 +170,8 @@ namespace UnitTestEx.Generic
 
             exception ??= validationResult?.ToException();
             ExceptionSuccessExpectations.Assert(exception);
+            EventExpectations.Assert();
+            LoggerExpectations.Assert(messages);
             return new ValueAssertor<IValidationResult>(validationResult!, exception, Implementor, JsonSerializer);
         }
 
@@ -254,6 +259,8 @@ namespace UnitTestEx.Generic
             Implementor.WriteLine("");
 
             ExceptionSuccessExpectations.Assert(exception);
+            EventExpectations.Assert();
+            LoggerExpectations.Assert(messages);
             return new VoidAssertor(exception, Implementor, JsonSerializer);
         }
     }

--- a/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
@@ -187,7 +187,7 @@ namespace UnitTestEx.Mocking
 
                             if (JsonElement.TryParseValue(ref cur, out JsonElement? cje) && JsonElement.TryParseValue(ref bur, out JsonElement? bje))
                             {
-                                var differences = new JsonElementComparer(5).Compare((JsonElement)cje, (JsonElement)bje, _membersToIgnore);
+                                var differences = JsonElementComparer.Default.Compare((JsonElement)cje, (JsonElement)bje, _membersToIgnore);
                                 if (differences != null && _traceRequestComparisons)
                                     Implementor.WriteLine($"HTTP request JsonElementComparer differences: {differences}");
 
@@ -195,16 +195,12 @@ namespace UnitTestEx.Mocking
                             }
                         }
 
-                        var cc = ObjectComparer.CreateDefaultConfig();
-                        cc.MembersToIgnore.AddRange(_membersToIgnore!);
-
-                        var cl = new CompareLogic(cc);
                         var cv = JsonSerializer.Deserialize(body, _content!.GetType());
-                        var cr = cl.Compare(_content, cv);
-                        if (!cr.AreEqual && _traceRequestComparisons)
-                            Implementor.WriteLine($"HTTP request ObjectComparer differences: {cr.DifferencesString}");
+                        var cr = JsonElementComparer.Default.CompareValues(_content, cv, JsonSerializer, _membersToIgnore);
+                        if (cr is not null && _traceRequestComparisons)
+                            Implementor.WriteLine($"HTTP request JsonElementComparer differences: {cr}");
 
-                        return cr.AreEqual;
+                        return cr is null;
                     }
                     catch
                     {

--- a/src/UnitTestEx/TestSetUp.cs
+++ b/src/UnitTestEx/TestSetUp.cs
@@ -145,7 +145,7 @@ namespace UnitTestEx
         /// Gets or sets the <see cref="Expectations.EventExpectations.Expect(string?, EventData, string[])"/> and <see cref="Expectations.EventExpectations.Expect(string?, string, EventData, string[])"/> members to ignore.
         /// </summary>
         /// <remarks>By default <see cref="EventDataBase.Id"/>, <see cref="EventDataBase.CorrelationId"/>, <see cref="EventDataBase.Timestamp"/>, <see cref="EventDataBase.ETag"/> and <see cref="EventDataBase.Key"/> are ignored.</remarks>
-        public List<string> ExpectedEventsMembersToIgnore { get; set; } = new() { nameof(EventDataBase.Id), nameof(EventDataBase.CorrelationId), nameof(EventDataBase.Timestamp), nameof(EventDataBase.ETag), nameof(EventDataBase.Key) };
+        public List<string> ExpectedEventsPathsToIgnore { get; set; } = new() { nameof(EventDataBase.Id), nameof(EventDataBase.CorrelationId), nameof(EventDataBase.Timestamp), nameof(EventDataBase.ETag), nameof(EventDataBase.Key) };
 
         /// <summary>
         /// Gets or sets the <see cref="Expectations.EventExpectations"/> <see cref="Wildcard"/> parser.
@@ -193,7 +193,7 @@ namespace UnitTestEx
             ConcurrencyErrorETag = ConcurrencyErrorETag,
             ExpectedEventsEnabled = ExpectedEventsEnabled,
             ExpectNoEvents = ExpectNoEvents,
-            ExpectedEventsMembersToIgnore = ExpectedEventsMembersToIgnore,
+            ExpectedEventsPathsToIgnore = ExpectedEventsPathsToIgnore,
             ExpectedEventsWildcard = ExpectedEventsWildcard,
             ExpectedEventsEventDataFormatter = ExpectedEventsEventDataFormatter,
             ConfigureServices = ConfigureServices,

--- a/src/UnitTestEx/UnitTestEx.csproj
+++ b/src/UnitTestEx/UnitTestEx.csproj
@@ -16,11 +16,11 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.79.0" />
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.0.0" />
-    <PackageReference Include="CoreEx.Azure" Version="3.0.0" />
-    <PackageReference Include="CoreEx.Newtonsoft" Version="3.0.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.3.0" />
+    <PackageReference Include="CoreEx.Newtonsoft" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
@@ -28,11 +28,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tests/UnitTestEx.MSTest.Test/Other/ObjectComparerTest.cs
+++ b/tests/UnitTestEx.MSTest.Test/Other/ObjectComparerTest.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using UnitTestEx.MSTest.Test.Model;
 
 namespace UnitTestEx.MSTest.Test.Other
 {
     [TestClass]
+    [Obsolete($"This is being replaced by the {nameof(UnitTestEx.Abstractions.JsonElementComparer)} and usage of paths to ignore (versus members) to be more explicit.")]
     public class ObjectComparerTest
     {
         [TestMethod]

--- a/tests/UnitTestEx.NUnit.Test/Other/ExpectationsTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/ExpectationsTest.cs
@@ -378,7 +378,7 @@ namespace UnitTestEx.NUnit.Test.Other
             e = new EventExpectations(t);
             e.Expect(null, new CoreEx.Events.EventData { Source = new Uri("mydata/xyz", UriKind.Relative), Subject = "data.abc", Action = "created", TenantId = "yy" });
             var ex = Assert.Throws<AssertionException>(() => e.Assert());
-            Assert.IsTrue(ex.Message.Contains("Expected.TenantId != Actual.TenantId"), ex.Message);
+            Assert.IsTrue(ex.Message.Contains("Path 'tenantId' value is not equal: \"yy\" != \"xx\""), ex.Message);
 
             e = new EventExpectations(t);
             e.Expect(null, new CoreEx.Events.EventData { Source = new Uri("mydata/xyz", UriKind.Relative), Subject = "data.abc", Action = "created", TenantId = "yy" }, "TenantId");
@@ -403,7 +403,7 @@ namespace UnitTestEx.NUnit.Test.Other
             Assert.Throws<AssertionException>(() => e.Assert());
 
             e = new EventExpectations(t);
-            e.Expect(null, new CoreEx.Events.EventData<Person> { Source = new Uri("mydata/xyz", UriKind.Relative), Subject = "data.abc", Action = "created", TenantId = "xx", Value = new Person { Id = 1, FirstName = "Mary", LastName = "Contrary" } }, "LastName");
+            e.Expect(null, new CoreEx.Events.EventData<Person> { Source = new Uri("mydata/xyz", UriKind.Relative), Subject = "data.abc", Action = "created", TenantId = "xx", Value = new Person { Id = 1, FirstName = "Mary", LastName = "Contrary" } }, "value.LastName");
             e.Assert();
         }
 
@@ -454,7 +454,7 @@ namespace UnitTestEx.NUnit.Test.Other
 
             public string Name { get; set; }
 
-            public CompositeKey PrimaryKey => new CompositeKey(Id);
+            public CompositeKey PrimaryKey => new(Id);
 
             public ChangeLog ChangeLog { get; set; }
 

--- a/tests/UnitTestEx.NUnit.Test/Other/ExpectationsTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/ExpectationsTest.cs
@@ -249,7 +249,7 @@ namespace UnitTestEx.NUnit.Test.Other
 
             // By expecting the properties they should be automatically excluded from the value comparison.
             e = new ResponseValueExpectations<object, Entity<Guid>>(GenericTester.Create(), new object());
-            e.SetExpectValue(_ => new Entity<Guid> { Name = "Bob" });
+            e.SetExpectValue(_ => new Entity<Guid> { Name = "Bob", ChangeLog = new ChangeLog { CreatedBy = "Anonymous", CreatedDate = DateTime.UtcNow } });
             e.SetExpectIdentifier();
             e.SetExpectETag();
             e.SetExpectChangeLogCreated();

--- a/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
@@ -1,4 +1,7 @@
-﻿using NUnit.Framework;
+﻿using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
 using UnitTestEx.Expectations;
 
 namespace UnitTestEx.NUnit.Test.Other
@@ -22,5 +25,42 @@ namespace UnitTestEx.NUnit.Test.Other
             test.ExpectErrorType(CoreEx.Abstractions.ErrorType.ValidationError, "Badness.")
                 .Run(() => throw new CoreEx.ValidationException("Badness."));
         }
+
+        [Test]
+        public void Run_Service()
+        {
+            using var test = GenericTester.Create().ConfigureServices(services => services.AddSingleton<Gin>());
+
+            test.Run<Gin, int>(gin => gin.Pour())
+                .AssertSuccess()
+                .Assert(1);
+
+            test.Run<Gin, int>(gin => gin.PourAsync())
+                .AssertSuccess()
+                .Assert(1);
+
+            test.Run<Gin>(gin => gin.Shake())
+                .AssertSuccess();
+
+            test.Run<Gin>(gin => gin.ShakeAsync())
+                .AssertSuccess();
+
+            test.Run<Gin>(gin => gin.Stir())
+                .AssertException<DivideByZeroException>("As required by Bond; shaken, not stirred.");
+
+            test.Run<Gin>(gin => gin.StirAsync())
+                .AssertException<DivideByZeroException>("As required by Bond; shaken, not stirred.");
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Just for testing aye bro!")]
+    public class Gin
+    {
+        public void Stir() => throw new DivideByZeroException("As required by Bond; shaken, not stirred.");
+        public Task StirAsync() => throw new DivideByZeroException("As required by Bond; shaken, not stirred.");
+        public void Shake() { }
+        public Task ShakeAsync() => Task.CompletedTask;
+        public int Pour() => 1;
+        public Task<int> PourAsync() => Task.FromResult(1);
     }
 }

--- a/tests/UnitTestEx.NUnit.Test/Other/ObjectComparerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/ObjectComparerTest.cs
@@ -1,9 +1,11 @@
 ﻿using NUnit.Framework;
+using System;
 using UnitTestEx.NUnit.Test.Model;
 
 namespace UnitTestEx.NUnit.Test.Other
 {
     [TestFixture]
+    [Obsolete($"This is being replaced by the {nameof(UnitTestEx.Abstractions.JsonElementComparer)} and usage of paths to ignore (versus members) to be more explicit.")]
     public class ObjectComparerTest
     {
         [Test]

--- a/tests/UnitTestEx.Xunit.Test/Other/ObjectComparerTest.cs
+++ b/tests/UnitTestEx.Xunit.Test/Other/ObjectComparerTest.cs
@@ -1,9 +1,11 @@
-﻿using UnitTestEx.Xunit.Test.Model;
+﻿using System;
+using UnitTestEx.Xunit.Test.Model;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace UnitTestEx.Xunit.Test.Other
 {
+    [Obsolete($"This is being replaced by the {nameof(UnitTestEx.Abstractions.JsonElementComparer)} and usage of paths to ignore (versus members) to be more explicit.")]
     public class ObjectComparerTest : UnitTestBase
     {
         public ObjectComparerTest(ITestOutputHelper output) : base(output) { }


### PR DESCRIPTION
- *Enhancement:* Updated all package depenedencies to latest.
- *Enhancement:* The `GenericTester` updated to support `IHostStartup` to enable shared host dependency injection configuration.
- *Enhancement:* Added `IEventExpectations<TSelf>` and `ILoggerExpectations<TSelf>` support to `GenericTester` and `ValidationTester`.
- *Enhancement:* Moved the `CreateServiceBusMessage` and related methods from `FunctionTesterBase` up the inheritance hierarchy to `TesterBase<TSelf>` to enable broader usage.
- *Enhancement:* Added `ExpectEventFromJsonResource` and `ExpectDestinationEventFromJsonResource` expectations to simplify specification versus having to instantiate `EventData`.
- *Enhancement:* The `JsonElementComparer` now defaults to case-insensitive comparison.
- *Enhancement:* All internal usage of the `ObjectComparer` replaced with usage of the `JsonElementComparer` to break external dependency. All `MembersToIgnore` have been replaced with `PathsToIgnore` (being the fully-qualified JSON path) as this is more explicit and less error prone. The `ObjectComparer` has been flagged as `Obsolete` and will be removed in a later version.
