### PR TITLE
Changes to app config load ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v4.0.1
+- *Fixed:* The `FunctionTesterBase` was updated to correctly load the configuration in the order similar to that performed by the Azure Functions runtime fabric.
+- *Fixed:* Removed all dependencies to `Newtonsoft.Json`; a developer will need to explicitly add this dependency and `IJsonSerializer` implementation where applicable.
+
 ## v4.0.0
 All internal dependecies to `CoreEx` have been removed. This is intended to further generalize the capabilities of `UnitTestEx`; but more importantly, break the circular dependency reference between the two repositories. New `CoreEx.UnitTesting*` packages have been created to extend the `UnitTestEx` capabilities for `CoreEx`.
  - *Enhancement:* All typed value assertions have been named `AssertValue` for consistency; otherwise, `AssertContent` for a simple string comparison.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>4.0.0</Version>
+		<Version>4.0.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ test.Controller<PersonController>()
 
 _UnitTestEx_ supports the addition of a `appsettings.unittest.json` within the test project that will get loaded automatically when executing tests. This enables settings to be added or modified specifically for the unit testing external to the referenced projects being tested.
 
-Additionally, this can also be used to change the default JSON Serializer for the tests. Defaults to `CoreEx.Text.Json.JsonSerializer`. By adding the following setting the default JSON serializer will be updated at first test execution and will essentially override for all tests. To change serializer for a specific test then use the test classes to specify explicitly.
+Additionally, this can also be used to change the default JSON Serializer for the tests. Defaults to `UnitTestEx.Json.JsonSerializer` (leverages `System.Text.Json`). By adding the following setting the default JSON serializer will be updated at first test execution and will essentially override for all tests. To change serializer for a specific test then use the test classes to specify explicitly.
 
 ``` json
 {
-  "DefaultJsonSerializer": "Newtonsoft.Json"
+  "DefaultJsonSerializer": "UnitTestEx.MSTest.Test.NewtonsoftJsonSerializer, UnitTestEx.MSTest.Test"
 }
 ```
 

--- a/src/UnitTestEx/Abstractions/TesterBase.cs
+++ b/src/UnitTestEx/Abstractions/TesterBase.cs
@@ -32,14 +32,13 @@ namespace UnitTestEx.Abstractions
 
                 var json = System.Text.Json.JsonDocument.Parse(File.ReadAllText(fi.FullName));
                 if (json.RootElement.TryGetProperty("DefaultJsonSerializer", out var je) && je.ValueKind == System.Text.Json.JsonValueKind.String)
-                {
-                    if (string.Compare(je.GetString(), "System.Text.Json", StringComparison.InvariantCultureIgnoreCase) == 0)
-                        TestSetUp.Default.JsonSerializer = Json.JsonSerializer.Default = new Json.JsonSerializer();
-                    else if (string.Compare(je.GetString(), "Newtonsoft.Json", StringComparison.InvariantCultureIgnoreCase) == 0)
-                        TestSetUp.Default.JsonSerializer = Json.JsonSerializer.Default = new Json.Newtonsoft.JsonSerializer();
-                }
+                    TestSetUp.Default.JsonSerializer = (IJsonSerializer)Activator.CreateInstance(Type.GetType(je.GetString()!)!)!;
             }
-            catch { } // Swallow and carry on; none of this logic should impact execution.
+            catch (Exception ex)
+            {
+                // Swallow and carry on; none of this logic should impact execution.
+                System.Diagnostics.Debug.WriteLine($"UnitTestEx attempted to read, then load (if specified) the 'DefaultJsonSerializer' from, 'appsettings.unittest.json': {ex}.");
+            }
         }
 
         /// <summary>

--- a/src/UnitTestEx/Functions/FunctionTesterBase.cs
+++ b/src/UnitTestEx/Functions/FunctionTesterBase.cs
@@ -154,9 +154,14 @@ namespace UnitTestEx.Functions
                         if ((!_includeUserSecrets.HasValue && TestSetUp.FunctionTesterIncludeUserSecrets) || (_includeUserSecrets.HasValue && _includeUserSecrets.Value))
                             cb.AddUserSecrets<TEntryPoint>();
 
-                        cb.AddEnvironmentVariables();
-
                         ep3?.ConfigureHostConfiguration(cb);
+                    })
+                    .ConfigureAppConfiguration((hbc, cb) =>
+                    {
+                        ep2?.ConfigureAppConfiguration(MockIFunctionsConfigurationBuilder(cb));
+                        ep3?.ConfigureAppConfiguration(hbc, cb);
+
+                        cb.AddEnvironmentVariables();
 
                         // Apply early so can be reference.
                         if ((!_includeUnitTestConfiguration.HasValue && TestSetUp.FunctionTesterIncludeUnitTestConfiguration) || (_includeUnitTestConfiguration.HasValue && _includeUnitTestConfiguration.Value))
@@ -164,11 +169,6 @@ namespace UnitTestEx.Functions
 
                         if (_additionalConfiguration != null)
                             cb.AddInMemoryCollection(_additionalConfiguration);
-                    })
-                    .ConfigureAppConfiguration((hbc, cb) =>
-                    {
-                        ep2?.ConfigureAppConfiguration(MockIFunctionsConfigurationBuilder(cb));
-                        ep3?.ConfigureAppConfiguration(hbc, cb);
                     })
                     .ConfigureServices(sc =>
                     {

--- a/src/UnitTestEx/Generic/GenericTesterBase.cs
+++ b/src/UnitTestEx/Generic/GenericTesterBase.cs
@@ -82,8 +82,7 @@ namespace UnitTestEx.Generic
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
         public async Task<VoidAssertor> RunAsync(Func<Task> function)
         {
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
+            ArgumentNullException.ThrowIfNull(function);
 
             TestSetUp.LogAutoSetUpOutputs(Implementor);
 
@@ -210,8 +209,7 @@ namespace UnitTestEx.Generic
         /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
         public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<Task<TValue>> function)
         {
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
+            ArgumentNullException.ThrowIfNull(function);
 
             TestSetUp.LogAutoSetUpOutputs(Implementor);
 

--- a/src/UnitTestEx/Generic/GenericTesterCore.cs
+++ b/src/UnitTestEx/Generic/GenericTesterCore.cs
@@ -55,17 +55,18 @@ namespace UnitTestEx.Generic
                 return _host ??= new HostBuilder()
                     .UseEnvironment(TestSetUp.Environment)
                     .ConfigureLogging((lb) => { lb.SetMinimumLevel(SetUp.MinimumLogLevel); lb.ClearProviders(); lb.AddProvider(LoggerProvider); })
-                    .ConfigureHostConfiguration(ep.ConfigureHostConfiguration)
+                    .ConfigureHostConfiguration(cb =>
+                    {
+                        cb.SetBasePath(Environment.CurrentDirectory);
+                        ep.ConfigureHostConfiguration(cb);
+                        cb.AddJsonFile("appsettings.json", optional: true)
+                          .AddJsonFile($"appsettings.{TestSetUp.Environment.ToLowerInvariant()}.json", optional: true);
+                    })
                     .ConfigureAppConfiguration((hbc, cb) =>
                     {
-                        cb.SetBasePath(Environment.CurrentDirectory)
-                          .AddJsonFile("appsettings.json", optional: true)
-                          .AddJsonFile($"appsettings.{TestSetUp.Environment.ToLowerInvariant()}.json", optional: true)
-                          .AddEnvironmentVariables();
-
                         ep.ConfigureAppConfiguration(hbc, cb);
-
-                        cb.AddJsonFile("appsettings.unittest.json", optional: true);
+                        cb.AddJsonFile("appsettings.unittest.json", optional: true)
+                          .AddEnvironmentVariables();
                     })
                     .ConfigureServices(sc =>
                     {

--- a/src/UnitTestEx/UnitTestEx.csproj
+++ b/src/UnitTestEx/UnitTestEx.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Moq" Version="4.20.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.15.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.11.0" />
   </ItemGroup>

--- a/tests/UnitTestEx.MSTest.Test/NewtonsoftJsonSerializer.cs
+++ b/tests/UnitTestEx.MSTest.Test/NewtonsoftJsonSerializer.cs
@@ -1,17 +1,19 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
+using UnitTestEx.Json;
 using Nsj = Newtonsoft.Json;
 
-namespace UnitTestEx.Json.Newtonsoft
+namespace UnitTestEx.MSTest.Test
 {
     /// <summary>
     /// Provides the <see cref="Nsj.JsonSerializer"/> encapsulated implementation.
     /// </summary>
-    /// <param name="settings">The <see cref="Nsj.JsonSerializerSettings"/>. Defaults to <see cref="DefaultSettings"/>.</param>
-    public class JsonSerializer(Nsj.JsonSerializerSettings? settings = null) : IJsonSerializer
+    public class NewtonsoftJsonSerializer : IJsonSerializer
     {
         /// <summary>
         /// Gets or sets the default <see cref="Nsj.JsonSerializerSettings"/>.
@@ -25,13 +27,24 @@ namespace UnitTestEx.Json.Newtonsoft
             ContractResolver = new Nsj.Serialization.CamelCasePropertyNamesContractResolver(),
         };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewtonsoftJsonSerializer"/> class.
+        /// </summary>
+        public NewtonsoftJsonSerializer() => Settings = DefaultSettings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewtonsoftJsonSerializer"/> class.
+        /// </summary>
+        /// <param name="settings">The <see cref="Nsj.JsonSerializerSettings"/>. Defaults to <see cref="DefaultSettings"/>.</param>
+        public NewtonsoftJsonSerializer(Nsj.JsonSerializerSettings? settings = null) => Settings = settings ?? DefaultSettings;
+
         /// <inheritdoc/>
         object IJsonSerializer.Options => Settings;
 
         /// <summary>
         /// Gets the <see cref="Nsj.JsonSerializerSettings"/>.
         /// </summary>
-        public Nsj.JsonSerializerSettings Settings { get; } = settings ?? DefaultSettings;
+        public Nsj.JsonSerializerSettings Settings { get; } 
 
         /// <inheritdoc/>
         public object? Deserialize(string json) => Deserialize<dynamic>(json);
@@ -94,3 +107,5 @@ namespace UnitTestEx.Json.Newtonsoft
         }
     }
 }
+
+#nullable restore

--- a/tests/UnitTestEx.MSTest.Test/PersonControllerTest.cs
+++ b/tests/UnitTestEx.MSTest.Test/PersonControllerTest.cs
@@ -15,6 +15,13 @@ namespace UnitTestEx.MSTest.Test
     public class PersonControllerTest
     {
         [TestMethod]
+        public void VerifyNewtonsoftJsonSerializer()
+        {
+            using var test = ApiTester.Create<Startup>();
+            Assert.IsInstanceOfType(TestSetUp.Default.JsonSerializer, typeof(NewtonsoftJsonSerializer));
+        }
+
+        [TestMethod]
         public async Task Get_Test1()
         {
             using var test = ApiTester.Create<Startup>();
@@ -28,7 +35,7 @@ namespace UnitTestEx.MSTest.Test
         public void Get_Test2()
         {
             int id = 2;
-            using var test = ApiTester.Create<Startup>().UseJsonSerializer(new UnitTestEx.Json.Newtonsoft.JsonSerializer());
+            using var test = ApiTester.Create<Startup>().UseJsonSerializer(new NewtonsoftJsonSerializer());
             test.Controller<PersonController>()
                 .Run(c => c.Get(id))
                 .AssertOK()

--- a/tests/UnitTestEx.MSTest.Test/appsettings.unittest.json
+++ b/tests/UnitTestEx.MSTest.Test/appsettings.unittest.json
@@ -1,4 +1,4 @@
 {
   "SpecialKey": "VerySpecialValue",
-  "DefaultJsonSerializer": "Newtonsoft.Json"
+  "DefaultJsonSerializer": "UnitTestEx.MSTest.Test.NewtonsoftJsonSerializer, UnitTestEx.MSTest.Test"
 }


### PR DESCRIPTION
This should fix issue so that appsettings.unittest.json (when used in tests) properly will overwrite any appsettings.json values defined in function or asp.net project.