### PR TITLE
v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v4.1.1
+- *Fixed:* The `TypeTester` was not correctly capturing and outputting any of the logging, and also (as a result) the `ExpectLogContains` was not functioning as expected.
+
 ## v4.1.0
 - *Enhancement:* Removed the `FunctionsStartup` constraint for `TEntryPoint` to enable more generic usage.
 - *Enhancement:* Enable `Microsoft.Azure.Functions.Worker.HttpTriggerAttribute` (new [_isolated_](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide) function support), in addition to existing `Microsoft.Azure.WebJobs.HttpTriggerAttribute` (existing [_in-process_](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library) function support), within `HttpTriggerTester`.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>4.1.0</Version>
+		<Version>4.1.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/tests/UnitTestEx.Function/ProductFunction.cs
+++ b/tests/UnitTestEx.Function/ProductFunction.cs
@@ -15,10 +15,12 @@ namespace UnitTestEx.Function
     public class ProductFunction
     {
         private readonly HttpClient _httpClient;
+        private readonly ILogger<ProductFunction> _logger;
 
-        public ProductFunction(IHttpClientFactory clientFactory)
+        public ProductFunction(IHttpClientFactory clientFactory, ILogger<ProductFunction> logger)
         {
             _httpClient = clientFactory.CreateClient("XXX");
+            _logger = logger;
         }
 
         [FunctionName("ProductFunction")]
@@ -45,8 +47,10 @@ namespace UnitTestEx.Function
         }
 
         [FunctionName("TimerTriggered")]
-        public Task DailyRun([TimerTrigger("0 0 0 */1 * *", RunOnStartup = true)] TimerInfo _)
+        public Task DailyRun([TimerTrigger("0 0 0 */1 * *", RunOnStartup = true)] TimerInfo _, ILogger otherLogger)
         {
+            _logger.LogInformation("C# Timer trigger function executed (DI).");
+            otherLogger.LogInformation("C# Timer trigger function executed (method).");
             return Task.CompletedTask;
         }
     }

--- a/tests/UnitTestEx.IsolatedFunction/TimerFunction.cs
+++ b/tests/UnitTestEx.IsolatedFunction/TimerFunction.cs
@@ -1,19 +1,23 @@
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
 
 namespace UnitTestEx.IsolatedFunction
 {
     public class TimerFunction
     {
         private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
 
-        public TimerFunction(IHttpClientFactory clientFactory)
+        public TimerFunction(IHttpClientFactory clientFactory, ILogger<TimerFunction> logger) 
         {
             _httpClient = clientFactory.CreateClient("XXX");
+            _logger = logger;
         }
 
         [Function("TimerTriggerFunction")]
         public async Task Run([TimerTrigger("0 */5 * * * *" /*, RunOnStartup = true */)] string _)
         {
+            _logger.LogInformation("C# Timer trigger function executed.");
             var hr = await _httpClient.GetAsync($"products/123").ConfigureAwait(false);
             hr.EnsureSuccessStatusCode();
         }

--- a/tests/UnitTestEx.NUnit.Test/ProductFunctionTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/ProductFunctionTest.cs
@@ -76,7 +76,9 @@ namespace UnitTestEx.NUnit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.Type<ProductFunction>()
-                .Run(f => f.DailyRun(new TimerInfo(new DailySchedule("2:00:00"), It.IsAny<ScheduleStatus>(), false)))
+                .ExpectLogContains("(DI)")
+                .ExpectLogContains("(method)")
+                .Run(f => f.DailyRun(new TimerInfo(new DailySchedule("2:00:00"), It.IsAny<ScheduleStatus>(), false), test.Logger))
                 .AssertSuccess();
         }   
     }


### PR DESCRIPTION
- *Fixed:* The `TypeTester` was not correctly capturing and outputting any of the logging, and also (as a result) the `ExpectLogContains` was not functioning as expected.
