### PR TITLE
v4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v4.1.2
+- *Fixed*: The `AssertLocationHeader` has been corrected to also support the specification of the `Uri` as a string. Additionally, contains support has been added with `AssertLocationHeaderContains`.
+
 ## v4.1.1
 - *Fixed:* The `TypeTester` was not correctly capturing and outputting any of the logging, and also (as a result) the `ExpectLogContains` was not functioning as expected.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>4.1.1</Version>
+		<Version>4.1.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertor.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertor.cs
@@ -16,6 +16,17 @@ namespace UnitTestEx.Assertors
     public class HttpResponseMessageAssertor(TesterBase owner, HttpResponseMessage response) : HttpResponseMessageAssertorBase<HttpResponseMessageAssertor>(owner, response)
     {
         /// <summary>
+        /// Asserts the the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> matches the <paramref name="expectedUri"/>.
+        /// </summary>
+        /// <param name="expectedUri">The expected <see cref="Uri"/>.</param>
+        /// <returns>The <see cref="HttpResponseMessageAssertor"/> to support fluent-style method-chaining.</returns>
+        public HttpResponseMessageAssertor AssertLocationHeader(Uri expectedUri)
+        {
+            Implementor.AssertAreEqual(expectedUri, Response.Headers?.Location, $"Expected and Actual HTTP Response Header '{HeaderNames.Location}' values are not equal.");
+            return this;
+        }
+
+        /// <summary>
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> matches the <paramref name="expectedUri"/> result.
         /// </summary>
         /// <param name="expectedUri">The expected <see cref="Uri"/> function.</param>
@@ -25,6 +36,33 @@ namespace UnitTestEx.Assertors
             Implementor.AssertAreEqual(expectedUri?.Invoke(GetValue<TValue>()), Response.Headers?.Location, $"Expected and Actual HTTP Response Header '{HeaderNames.Location}' values are not equal.");
             return this;
         }
+
+        /// <summary>
+        /// Asserts the the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> contains the <paramref name="expected"/> string.
+        /// </summary>
+        /// <param name="expected">The expected string.</param>
+        /// <returns>The <see cref="HttpResponseMessageAssertor"/> to support fluent-style method-chaining.</returns>
+        public HttpResponseMessageAssertor AssertLocationHeaderContains(string expected)
+        {
+            if (string.IsNullOrEmpty(expected))
+                throw new ArgumentNullException(nameof(expected));
+
+            if (Response.Headers?.Location == null)
+                Implementor.AssertFail($"The Actual HTTP Response Header '{HeaderNames.Location}' must not be null.");
+
+            if (!Response.Headers!.Location!.ToString().Contains(expected))
+                Implementor.AssertFail($"Actual HTTP Response Header '{HeaderNames.Location}' must contain expected.");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Asserts the the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> contains the <paramref name="expected"/> string result.
+        /// </summary>
+        /// <param name="expected">The expected string.</param>
+        /// <returns>The <see cref="HttpResponseMessageAssertor"/> to support fluent-style method-chaining.</returns>
+        public HttpResponseMessageAssertor AssertLocationHeaderContains<TValue>(Func<TValue?, string> expected)
+            => AssertLocationHeaderContains(expected?.Invoke(GetValue<TValue>())!);
 
         /// <summary>
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> matches the <paramref name="expectedValue"/>.

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorT.cs
@@ -48,6 +48,17 @@ namespace UnitTestEx.Assertors
         }
 
         /// <summary>
+        /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> matches the <paramref name="expected"/> string.
+        /// </summary>
+        /// <param name="expected">The expected string.</param>
+        /// <returns>The <see cref="HttpResponseMessageAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
+        public HttpResponseMessageAssertor<TValue> AssertLocationHeader(Func<TValue?, string> expected)
+        {
+            Implementor.AssertAreEqual(expected?.Invoke(GetValue<TValue>()), Response.Headers?.Location?.ToString(), $"Expected and Actual HTTP Response Header '{HeaderNames.Location}' values are not equal.");
+            return this;
+        }
+
+        /// <summary>
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> matches the <paramref name="expectedUri"/> result.
         /// </summary>
         /// <param name="expectedUri">The expected <see cref="Uri"/> function.</param>
@@ -57,6 +68,33 @@ namespace UnitTestEx.Assertors
             Implementor.AssertAreEqual(expectedUri?.Invoke(GetValue<TValue>()), Response.Headers?.Location, $"Expected and Actual HTTP Response Header '{HeaderNames.Location}' values are not equal.");
             return this;
         }
+
+        /// <summary>
+        /// Asserts the the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> contains the <paramref name="expected"/> string.
+        /// </summary>
+        /// <param name="expected">The expected string.</param>
+        /// <returns>The <see cref="HttpResponseMessageAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
+        public HttpResponseMessageAssertor<TValue> AssertLocationHeaderContains(string expected)
+        {
+            if (string.IsNullOrEmpty(expected))
+                throw new ArgumentNullException(nameof(expected));
+
+            if (Response.Headers?.Location == null)
+                Implementor.AssertFail($"The Actual HTTP Response Header '{HeaderNames.Location}' must not be null.");
+
+            if (!Response.Headers!.Location!.ToString().Contains(expected))
+                Implementor.AssertFail($"Actual HTTP Response Header '{HeaderNames.Location}' must contain expected.");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Asserts the the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> contains the <paramref name="expected"/> string result.
+        /// </summary>
+        /// <param name="expected">The expected string.</param>
+        /// <returns>The <see cref="HttpResponseMessageAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
+        public HttpResponseMessageAssertor<TValue> AssertLocationHeaderContains(Func<TValue?, string> expected)
+            => AssertLocationHeaderContains(expected?.Invoke(GetValue<TValue>())!);
 
         /// <summary>
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> matches the <paramref name="expectedValue"/>.


### PR DESCRIPTION
- *Fixed*: The `AssertLocationHeader` has been corrected to also support the specification of the `Uri` as a string. Additionally, contains support has been added with `AssertLocationHeaderContains`.