### PR TITLE
v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v4.3.0
+- *Enhancement:* A new `MockHttpClient.WithRequestsFromResource` method enables the specification of the Request/Response configuration from a YAML/JSON embedded resource. The [`mock.unittestex.json`](./src/UnitTestEx/Schema/mock.unittestex.json) JSON schema defines content.
+
 ## v4.2.0
 - *Enhancement:* Any configuration specified as part of registering the `HttpClient` services from a Dependency Injection (DI) perspective is ignored by default when creating an `HttpClient` using the `MockHttpClientFactory`. This default behavior is intended to potentially minimize any side-effect behavior that may occur that is not intended for the unit testing. See [`README`](./README.md#http-client-configurations) for more details on capabilities introduced; highlights are:
   - New `MockHttpClient.WithConfigurations` method indicates that the `HttpMessageHandler` and `HttpClient` configurations are to be used.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>4.2.0</Version>
+		<Version>4.3.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/README.md
+++ b/README.md
@@ -219,6 +219,60 @@ mc.Request(HttpMethod.Get, "products/kjl").Respond.WithSequence(s =>
 
 <br/>
 
+### YAML/JSON configuration
+
+The Request/Response configuration can also be specified within an embedded resource using YAML/JSON as required. The [`mock.unittestex.json`](./src/UnitTestEx/Schema/mock.unittestex.json) JSON schema defines content; where the file is named `*.unittestex.yaml` or `*.unittestex.json` then the schema-based intellisense and validation will occur within the likes of Visual Studio.
+
+To reference the YAML/JSON from a unit test the following is required:
+
+``` csharp
+var mcf = MockHttpClientFactory.Create();
+mcf.CreateClient("XXX", new Uri("https://unit-test")).WithRequestsFromResource("my.mock.unittestex.yaml");
+```
+
+The following represents a YAML example for one-to-one request/responses:
+
+``` yaml
+- method: post
+  uri: products/xyz
+  body: ^
+  response:
+    status: 202
+    body: |
+      {"product":"xyz","quantity":1}
+
+- method: get
+  uri: people/123
+  response:
+    body: |
+      {
+        "first":"Bob",
+        "last":"Jane"
+      }
+```
+
+The following represents a YAML example for a request/response with sequences:
+
+``` yaml
+- method: get
+  uri: people/123
+  sequence: 
+    - body: |
+        {
+          "first":"Bob",
+          "last":"Jane"
+        }
+    - body: |
+        {
+          "first":"Sarah",
+          "last":"Johns"
+        }
+```
+
+_Note:_ Not all scenarios are currently available using YAML/JSON configuration.
+
+<br/>
+
 ## Expectations
 
 By default _UnitTestEx_ provides out-of-the-box `Assert*` capabilities that are applied after execution to verify the test results. However, by adding the `UnitTestEx.Expectations` namespace in a test additional `Expect*` capabilities will be enabled (where applicable). These allow expectations to be defined prior to the execution which are automatically asserted on execution. 

--- a/src/UnitTestEx.NUnit/ObjectComparer.cs
+++ b/src/UnitTestEx.NUnit/ObjectComparer.cs
@@ -38,7 +38,7 @@ namespace UnitTestEx.NUnit
                 return;
             }
 
-            if (expected is null)
+            if (actual is null)
             {
                 new NUnitTestImplementor().AssertFail($"Expected and Actual values are not equal: value != NULL.");
                 return;
@@ -48,6 +48,46 @@ namespace UnitTestEx.NUnit
             o.JsonSerializer ??= TestSetUp.Default.JsonSerializer;
 
             var cr = new JsonElementComparer(o).CompareValue(expected, actual, pathsToIgnore);
+            if (cr.HasDifferences)
+                new NUnitTestImplementor().AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
+        }
+
+        /// <summary>
+        /// Compares two JSON strings to each other.
+        /// </summary>
+        /// <param name="expected">The expected JSON.</param>
+        /// <param name="actual">The actual JSON.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
+        public static void JsonAssert(string? expected, string? actual, params string[] pathsToIgnore) => JsonAssert(null, expected, actual, pathsToIgnore);
+        
+        /// <summary>
+        /// Compares two JSON strings to each other.
+        /// </summary>
+        /// <param name="options">The <see cref="JsonElementComparerOptions"/>.</param>
+        /// <param name="expected">The expected JSON.</param>
+        /// <param name="actual">The actual JSON.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
+        public static void JsonAssert(JsonElementComparerOptions? options, string? expected, string? actual, params string[] pathsToIgnore)
+        {
+            if (expected is null && actual is null)
+                return;
+
+            if (expected is null)
+            {
+                new NUnitTestImplementor().AssertFail($"Expected and Actual values are not equal: NULL != value.");
+                return;
+            }
+
+            if (actual is null)
+            {
+                new NUnitTestImplementor().AssertFail($"Expected and Actual values are not equal: value != NULL.");
+                return;
+            }
+
+            var o = (options ?? TestSetUp.Default.JsonComparerOptions).Clone();
+            o.JsonSerializer ??= TestSetUp.Default.JsonSerializer;
+
+            var cr = new JsonElementComparer(o).Compare(expected, actual, pathsToIgnore);
             if (cr.HasDifferences)
                 new NUnitTestImplementor().AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
         }

--- a/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
@@ -22,7 +22,7 @@ namespace UnitTestEx.Mocking
     {
         private readonly MockHttpClient _client;
         private readonly HttpMethod _method;
-        private readonly string _requestUri;
+        private readonly string? _requestUri;
         private bool _anyContent;
         private object? _content;
         private string? _mediaType;
@@ -40,11 +40,11 @@ namespace UnitTestEx.Mocking
         /// <param name="client">The <see cref="MockHttpClient"/>.</param>
         /// <param name="method">The <see cref="HttpMethod"/>.</param>
         /// <param name="requestUri">The string that represents the request <see cref="Uri"/>.</param>
-        internal MockHttpClientRequest(MockHttpClient client, HttpMethod method, string requestUri)
+        internal MockHttpClientRequest(MockHttpClient client, HttpMethod method, string? requestUri)
         {
             _client = client;
             _method = method ?? throw new ArgumentNullException(nameof(method));
-            _requestUri = requestUri ?? throw new ArgumentNullException(nameof(requestUri));
+            _requestUri = requestUri;
 
             Rule = new MockHttpClientRequestRule();
             Rule.Response = new MockHttpClientResponse(this, Rule);
@@ -151,7 +151,7 @@ namespace UnitTestEx.Mocking
             if (request.Method != _method)
                 return false;
 
-            var uri = new Uri(_requestUri, UriKind.RelativeOrAbsolute);
+            var uri = new Uri(_requestUri ?? string.Empty, UriKind.RelativeOrAbsolute);
             if (uri.IsAbsoluteUri)
             {
                 if (_client.IsBaseAddressSpecified && request.RequestUri != uri)
@@ -327,6 +327,15 @@ namespace UnitTestEx.Mocking
             _pathsToIgnore = pathsToIgnore;
             _mediaType = MediaTypeNames.Application.Json;
             return new MockHttpClientRequestBody(Rule);
+        }
+
+        /// <summary>
+        /// Sets the JSON paths to ignore from the comparison.
+        /// </summary>
+        internal MockHttpClientRequest WithPathsToIgnore(params string[] pathsToIgnore)
+        {
+            _pathsToIgnore = pathsToIgnore;
+            return this;
         }
 
         /// <summary>

--- a/src/UnitTestEx/Schema/mock.unittestex.json
+++ b/src/UnitTestEx/Schema/mock.unittestex.json
@@ -1,0 +1,79 @@
+{
+  "title": "JSON Schema for UnitTestEx HTTP request/response mocking (https://github.com/Avanade/unittestex).",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "definitions": {
+    "MockRequest": {
+      "type": "object",
+      "title": "The mocked HTTP request configuration.",
+      "properties": {
+        "method": {
+          "type": "string",
+          "title": "The HTTP Request Method; defaults to 'GET'."
+        },
+        "uri": {
+          "type": "string",
+          "title": "The HTTP Request URI (path and query)."
+        },
+        "body": {
+          "type": "string",
+          "title": "The HTTP Request Body (content)."
+        },
+        "media": {
+          "type": "string",
+          "title": "The HTTP Request Body (content) media type.",
+          "description": "Defaults to 'application/json' where the Body contains JSON; otherwise, 'text/plain'."
+        },
+        "ignore": {
+          "type": "array",
+          "title": "The HTTP Request Body JSON paths to ignore from the comparison.",
+          "description": "This is only applied where the 'media' is 'application/json'.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "response": {
+          "title": "The mocked HTTP response (singular) configuration",
+          "description": "The 'response' and 'sequence' are mutually exclusive.",
+          "$ref": "#/definitions/MockResponse"
+        },
+        "sequence": {
+          "type": "array",
+          "title": "The mocked HTTP responses array (sequence) configuration.",
+          "description": "The 'response' and 'sequence' are mutually exclusive.",
+          "items": {
+            "$ref": "#/definitions/MockResponse"
+          }
+        }
+      },
+      "not": {
+        "anyOf": [
+          { "required": [ "response", "sequence" ] }
+        ]
+      }
+    },
+    "MockResponse": {
+      "title": "The mocked HTTP response configuration.",
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "integer",
+          "title": "The HTTP Response status code.",
+          "description": "Defaults to 200-OK where there is a corresponding Body; otherwise, 204-No content."
+        },
+        "body": {
+          "type": "string",
+          "title": "The HTTP Response body (content)."
+        },
+        "media": {
+          "type": "string",
+          "title": "The HTTP Request Body (content) media type.",
+          "description": "Defaults to 'application/json' where the Body contains JSON; otherwise, 'text/plain'."
+        }
+      }
+    }
+  },
+  "items": {
+    "$ref": "#/definitions/MockRequest"
+  }
+}

--- a/src/UnitTestEx/UnitTestEx.csproj
+++ b/src/UnitTestEx/UnitTestEx.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.6" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/tests/UnitTestEx.MSTest.Test/MockHttpClientTest.cs
+++ b/tests/UnitTestEx.MSTest.Test/MockHttpClientTest.cs
@@ -468,7 +468,7 @@ namespace UnitTestEx.MSTest.Test
             Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
 
             var content = await res.Content.ReadAsStringAsync();
-            Assert.IsTrue(content.Contains("https://github.com/Avanade/unittestex", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(content.Contains("unittestex", StringComparison.OrdinalIgnoreCase));
          }
     }
 }

--- a/tests/UnitTestEx.NUnit.Test/Resources/mock.unittestex.yaml
+++ b/tests/UnitTestEx.NUnit.Test/Resources/mock.unittestex.yaml
@@ -1,0 +1,16 @@
+- method: post
+  uri: products/xyz
+  body: ^
+  response:
+    status: 202
+    body: |
+      {"product":"xyz","quantity":1}
+
+- method: get
+  uri: people/123
+  response:
+    body: |
+      {
+        "first":"Bob",
+        "last":"Jane"
+      }

--- a/tests/UnitTestEx.NUnit.Test/Resources/sequence.unittestex.yaml
+++ b/tests/UnitTestEx.NUnit.Test/Resources/sequence.unittestex.yaml
@@ -1,0 +1,13 @@
+- method: get
+  uri: people/123
+  sequence: 
+    - body: |
+        {
+          "first":"Bob",
+          "last":"Jane"
+        }
+    - body: |
+        {
+          "first":"Sarah",
+          "last":"Johns"
+        }

--- a/tests/UnitTestEx.NUnit.Test/UnitTestEx.NUnit.Test.csproj
+++ b/tests/UnitTestEx.NUnit.Test/UnitTestEx.NUnit.Test.csproj
@@ -8,7 +8,9 @@
   <ItemGroup>
     <None Remove="appsettings.unittest.json" />
     <None Remove="Resources\FunctionTest-ValidJsonResource.json" />
+    <None Remove="Resources\mock.unittestex.yaml" />
     <None Remove="Resources\MockHttpClientTest-UriAndBody_WithJsonResponse3.json" />
+    <None Remove="Resources\sequence.unittestex.yaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -19,6 +21,8 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\FunctionTest-ValidJsonResource.json" />
+    <EmbeddedResource Include="Resources\sequence.unittestex.yaml" />
+    <EmbeddedResource Include="Resources\mock.unittestex.yaml" />
     <EmbeddedResource Include="Resources\MockHttpClientTest-UriAndBody_WithJsonResponse3.json" />
   </ItemGroup>
 


### PR DESCRIPTION
- *Enhancement:* A new `MockHttpClient.WithRequestsFromResource` method enables the specification of the Request/Response configuration from a YAML/JSON embedded resource. The [`mock.unittestex.json`](./src/UnitTestEx/Schema/mock.unittestex.json) JSON schema defines content.