### PR TITLE
v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.1.0
+- *Enhancement:* Where an `HttpRequest` is used for an Azure Functions `HttpTriggerTester` the passed `HttpRequest.PathAndQuery` is checked against that defined by the corresponding `HttpTriggerAttribute.Route` and will result in an error where different. The `HttpTrigger.WithRouteChecK` and `WithNoRouteCheck` methods control the path and query checking as needed.
+
 ## v5.0.0
 - *Enhancement:* `UnitTestEx` package updated to include only standard .NET core capabilities; new packages created to house specific as follows:
   - `UnitTestEx.Azure.Functions` created to house Azure Functions specific capabilities;

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.0.0</Version>
+		<Version>5.1.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ test.ReplaceHttpClientFactory(mcf)
 
 Both the [_Isolated worker model_](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide) and [_In-process model_](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library) are supported.
 
+Additionally, where an `HttpRequest` is used the passed `HttpRequest.PathAndQuery` is checked against that defined by the corresponding `HttpTriggerAttribute.Route` and will result in an error where different. The `HttpTrigger.WithRouteChecK` and `WithNoRouteCheck` methods control the path and query checking as needed.
+
 <br/>
 
 ## Service Bus-trigger Azure Function
@@ -113,6 +115,14 @@ test.Run<Gin, int>(gin => gin.Pour())
 
 <br/>
 
+## DI Mocking
+
+Each of the aforementioned test capabilities support Dependency Injection (DI) mocking. This is achieved by replacing the registered services with mocks, stubs, or fakes. The [`TesterBase`](./src/UnitTestEx/Abstractions/TesterBaseT.cs) enables using the `Mock*`, `Replace*` and `ConfigureServices` methods. 
+
+The underlying `Services` property also provides access to the `IServiceCollection` within the underlying test host to enable further configuration as required.
+
+<br/>
+
 ## HTTP Client mocking
 
 Where invoking a down-stream system using an [`HttpClient`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient) within a unit test context this should generally be mocked. To enable _UnitTestEx_ provides a [`MockHttpClientFactory`](./src/UnitTestEx/Mocking/MockHttpClientFactory.cs) to manage each `HttpClient` (one or more), and mock a response based on the configured request. This leverages the [Moq](https://github.com/moq/moq4) framework internally to enable. One or more requests can also be configured per `HttpClient`.
@@ -131,6 +141,8 @@ test.ReplaceHttpClientFactory(mcf)
     .AssertOK()
     .Assert(new { id = "Abc", description = "A blue carrot" });
 ```
+
+The `ReplaceHttpClientFactory` leverages the `Replace*` capabilities discussed earlier in [DI Mocking](#di-mocking).
 
 <br/>
 

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
@@ -320,7 +320,7 @@ namespace UnitTestEx.Azure.Functions
 
             var context = new DefaultHttpContext();
 
-            var uri = new Uri(requestUri!, UriKind.RelativeOrAbsolute);
+            var uri = requestUri is null ? new Uri("http://functiontest") : new Uri(requestUri, UriKind.RelativeOrAbsolute);
             if (!uri.IsAbsoluteUri)
                 uri = new Uri($"http://functiontest{(requestUri != null && requestUri.StartsWith('/') ? requestUri : $"/{requestUri}")}");
 

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/RouteCheckOption.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/RouteCheckOption.cs
@@ -1,0 +1,38 @@
+﻿namespace UnitTestEx.Azure.Functions
+{
+    /// <summary>
+    /// Represents the route check option for the <see cref="HttpTriggerTester{TFunction}"/>.
+    /// </summary>
+    public enum RouteCheckOption
+    {
+        /// <summary>
+        /// No route check is required,
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The route should match the specified path excluding any query string.
+        /// </summary>
+        Path,
+
+        /// <summary>
+        /// The route should match the specified path including the query string.
+        /// </summary>
+        PathAndQuery,
+
+        /// <summary>
+        /// The route should start with the specified path and query string.
+        /// </summary>
+        PathAndQueryStartsWith,
+
+        /// <summary>
+        /// The route query (ignore path) should match the specified query string.
+        /// </summary>
+        Query,
+
+        /// <summary>
+        /// The route query (ignore path) should start with the specified query string.
+        /// </summary>
+        QueryStartsWith
+    }
+}

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/ServiceBusTriggerTester.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/ServiceBusTriggerTester.cs
@@ -69,13 +69,13 @@ namespace UnitTestEx.Azure.Functions
                 sbv = v;
                 foreach (var pi in p)
                 {
-                    if (pi is ServiceBusReceivedMessage sbrm)
+                    if (pi.Value is ServiceBusReceivedMessage sbrm)
                         sbv = sbrm;
-                    else if (pi is WebJobsServiceBusMessageActionsAssertor psba)
+                    else if (pi.Value is WebJobsServiceBusMessageActionsAssertor psba)
                         sba = psba;
-                    else if (pi is WebJobsServiceBusSessionMessageActionsAssertor pssba)
+                    else if (pi.Value is WebJobsServiceBusSessionMessageActionsAssertor pssba)
                         ssba = pssba;
-                    else if (pi is WorkerServiceBusMessageActionsAssertor pwsba)
+                    else if (pi.Value is WorkerServiceBusMessageActionsAssertor pwsba)
                         wsba = pwsba;
                 }
 

--- a/src/UnitTestEx.Azure.Functions/FunctionTester.cs
+++ b/src/UnitTestEx.Azure.Functions/FunctionTester.cs
@@ -7,7 +7,7 @@ using UnitTestEx.Azure.Functions;
 namespace UnitTestEx
 {
     /// <summary>
-    /// Provides the <b>NUnit</b> Function testing capability.
+    /// Provides the Function testing capability.
     /// </summary>
     public static class FunctionTester
     {

--- a/tests/UnitTestEx.Function/PersonFunction.cs
+++ b/tests/UnitTestEx.Function/PersonFunction.cs
@@ -69,6 +69,14 @@ namespace UnitTestEx.Function
             log.LogInformation("C# HTTP trigger function processed a request.");
             return new ContentResult { Content = JsonSerializer.Serialize(new { first = person.FirstName, last = person.LastName }), ContentType = MediaTypeNames.Application.Json, StatusCode = 200 };
         }
+
+        [FunctionName("PersonFunctionQuery")]
+        public async Task<IActionResult> RunWithQuery([HttpTrigger(AuthorizationLevel.Function, "get", Route = "api/people?name={name}")] HttpRequest request, string name, ILogger log)
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+            log.LogInformation("C# HTTP trigger function processed a request.");
+            return new OkObjectResult(new { name });
+        }
     }
 
     public class Namer

--- a/tests/UnitTestEx.MSTest.Test/PersonFunctionTest.cs
+++ b/tests/UnitTestEx.MSTest.Test/PersonFunctionTest.cs
@@ -13,6 +13,7 @@ namespace UnitTestEx.MSTest.Test
         {
             using var test = FunctionTester.Create<Startup>();
             (await test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .RunAsync(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person"), test.Logger)))
                 .AssertOK()
                 .AssertValue("This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response.");
@@ -23,6 +24,7 @@ namespace UnitTestEx.MSTest.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person?name=Trevor"), test.Logger))
                 .AssertOK()
                 .AssertValue("Hello, Trevor. This HTTP triggered function executed successfully.");
@@ -33,6 +35,7 @@ namespace UnitTestEx.MSTest.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Get, "person", new { name = "Jane" }), test.Logger))
                 .AssertOK()
                 .AssertValue("Hello, Jane. This HTTP triggered function executed successfully.");
@@ -43,6 +46,7 @@ namespace UnitTestEx.MSTest.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Post, "person", new { name = "Brian" }), test.Logger))
                 .AssertBadRequest()
                 .AssertErrors("Name cannot be Brian.");
@@ -53,6 +57,7 @@ namespace UnitTestEx.MSTest.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Post, "person", new { name = "Brian" }), test.Logger))
                 .AssertBadRequest()
                 .AssertErrors(new ApiError("name", "Name cannot be Brian."));
@@ -63,6 +68,7 @@ namespace UnitTestEx.MSTest.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Get, "person", new { name = "Rachel" }), test.Logger))
                 .AssertOK()
                 .AssertValue(new { FirstName = "Rachel", LastName = "Smith" });
@@ -73,6 +79,7 @@ namespace UnitTestEx.MSTest.Test
         {
             using var test = FunctionTester.Create<Startup>().UseJsonSerializer(new Json.JsonSerializer());
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Get, "person", new { name = "Rachel" }), test.Logger))
                 .AssertOK()
                 .AssertValueFromJsonResource<Person>("FunctionTest-ValidJsonResource.json");

--- a/tests/UnitTestEx.MSTest.Test/ProductFunctionTest.cs
+++ b/tests/UnitTestEx.MSTest.Test/ProductFunctionTest.cs
@@ -19,7 +19,7 @@ namespace UnitTestEx.MSTest.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/xyz"), "xyz", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/xyz"), "xyz", test.Logger))
                 .AssertNotFound();
         }
 
@@ -33,7 +33,7 @@ namespace UnitTestEx.MSTest.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/abc"), "abc", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/abc"), "abc", test.Logger))
                 .AssertOK()
                 .AssertValue(new { id = "Abc", description = "A blue carrot" });
         }
@@ -48,7 +48,7 @@ namespace UnitTestEx.MSTest.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .Type<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/abc"), "abc", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/abc"), "abc", test.Logger))
                 .ToActionResultAssertor()
                     .AssertOK()
                     .AssertValue(new { id = "Abc", description = "A blue carrot" });
@@ -62,7 +62,7 @@ namespace UnitTestEx.MSTest.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/exception"), "exception", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/exception"), "exception", test.Logger))
                 .AssertException<InvalidOperationException>("An unexpected exception occured.");
         }
     }

--- a/tests/UnitTestEx.NUnit.Test/IsolatedFunctionTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/IsolatedFunctionTest.cs
@@ -14,7 +14,7 @@ namespace UnitTestEx.NUnit.Test
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<HttpFunction>()
                 .ExpectLogContains("C# HTTP trigger function processed a request.")
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "hello")))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, null)))
                 .AssertSuccess();
         }
     }

--- a/tests/UnitTestEx.NUnit.Test/ProductFunctionTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/ProductFunctionTest.cs
@@ -23,7 +23,7 @@ namespace UnitTestEx.NUnit.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/xyz"), "xyz", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/xyz"), "xyz", test.Logger))
                 .AssertNotFound();
         }
 
@@ -38,7 +38,7 @@ namespace UnitTestEx.NUnit.Test
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
                 .ExpectLogContains("C# HTTP trigger function processed a request.")
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/abc"), "abc", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/abc"), "abc", test.Logger))
                 .AssertOK()
                 .AssertValue(new { id = "Abc", description = "A blue carrot" });
         }
@@ -67,7 +67,7 @@ namespace UnitTestEx.NUnit.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/exception"), "exception", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/exception"), "exception", test.Logger))
                 .AssertException<InvalidOperationException>("An unexpected exception occured.");
         }
 

--- a/tests/UnitTestEx.Xunit.Test/PersonFunctionTest.cs
+++ b/tests/UnitTestEx.Xunit.Test/PersonFunctionTest.cs
@@ -15,6 +15,7 @@ namespace UnitTestEx.Xunit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             (await test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .RunAsync(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person"), test.Logger)))
                 .AssertOK()
                 .AssertContent("This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response.");
@@ -25,6 +26,7 @@ namespace UnitTestEx.Xunit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person?name=Trevor"), test.Logger))
                 .AssertOK()
                 .AssertContent("Hello, Trevor. This HTTP triggered function executed successfully.");
@@ -35,6 +37,7 @@ namespace UnitTestEx.Xunit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Get, "person", new { name = "Jane" }), test.Logger))
                 .AssertOK()
                 .AssertContent("Hello, Jane. This HTTP triggered function executed successfully.");
@@ -45,6 +48,7 @@ namespace UnitTestEx.Xunit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Post, "person", new { name = "Brian" }), test.Logger))
                 .AssertBadRequest()
                 .AssertErrors("Name cannot be Brian.");
@@ -55,6 +59,7 @@ namespace UnitTestEx.Xunit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Post, "person", new { name = "Brian" }), test.Logger))
                 .AssertBadRequest()
                 .AssertErrors(new ApiError("name", "Name cannot be Brian."));
@@ -65,6 +70,7 @@ namespace UnitTestEx.Xunit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Post, "person", new { name = "Bruce" }), test.Logger))
                 .AssertBadRequest()
                 .AssertErrors("Name cannot be Bruce.");
@@ -75,6 +81,7 @@ namespace UnitTestEx.Xunit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Get, "person", new { name = "Rachel" }), test.Logger))
                 .AssertOK()
                 .AssertValue(new { FirstName = "Rachel", LastName = "Smith" });
@@ -85,6 +92,7 @@ namespace UnitTestEx.Xunit.Test
         {
             using var test = FunctionTester.Create<Startup>();
             test.HttpTrigger<PersonFunction>()
+                .WithNoRouteCheck()
                 .Run(f => f.Run(test.CreateJsonHttpRequest(HttpMethod.Get, "person", new { name = "Rachel" }), test.Logger))
                 .AssertOK()
                 .AssertValueFromJsonResource<Person>("FunctionTest-ValidJsonResource.json");

--- a/tests/UnitTestEx.Xunit.Test/ProductFunctionTest.cs
+++ b/tests/UnitTestEx.Xunit.Test/ProductFunctionTest.cs
@@ -22,7 +22,7 @@ namespace UnitTestEx.Xunit.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/xyz"), "xyz", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/xyz"), "xyz", test.Logger))
                 .AssertNotFound();
         }
 
@@ -36,7 +36,7 @@ namespace UnitTestEx.Xunit.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/abc"), "abc", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/abc"), "abc", test.Logger))
                 .AssertOK()
                 .AssertValue(new { id = "Abc", description = "A blue carrot" });
         }
@@ -51,7 +51,7 @@ namespace UnitTestEx.Xunit.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .Type<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/abc"), "abc", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/abc"), "abc", test.Logger))
                 .ToActionResultAssertor()
                     .AssertOK()
                     .AssertValue(new { id = "Abc", description = "A blue carrot" });
@@ -65,7 +65,7 @@ namespace UnitTestEx.Xunit.Test
             using var test = FunctionTester.Create<Startup>();
             test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
-                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "person/exception"), "exception", test.Logger))
+                .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/exception"), "exception", test.Logger))
                 .AssertException<InvalidOperationException>("An unexpected exception occured.");
         }
     }


### PR DESCRIPTION
- *Enhancement:* Where an `HttpRequest` is used for an Azure Functions `HttpTriggerTester` the passed `HttpRequest.PathAndQuery` is checked against that defined by the corresponding `HttpTriggerAttribute.Route` and will result in an error where different. The `HttpTrigger.WithRouteChecK` and `WithNoRouteCheck` methods control the path and query checking as needed.