### PR TITLE
v5.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-          3.1.x
           6.0.x
           7.0.x
           8.0.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.2.0
+- *Enhancement:* Added `TesterBase<TSelf>.UseAdditionalConfiguration` method to enable additional configuration to be specified that overrides the `IHostBuilder` as the host is being built. This leverages the underlying `IConfigurationBuilder.AddInMemoryCollection` capability to add. This is intended to support additional configuration that is not part of the standard `appsettings.json` or `appsettings.unittest.json` configuration.
+
 ## v5.1.0
 - *Enhancement:* Where an `HttpRequest` is used for an Azure Functions `HttpTriggerTester` the passed `HttpRequest.PathAndQuery` is checked against that defined by the corresponding `HttpTriggerAttribute.Route` and will result in an error where different. The `HttpTrigger.WithRouteChecK` and `WithNoRouteCheck` methods control the path and query checking as needed.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.1.0</Version>
+		<Version>5.2.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
@@ -36,7 +36,6 @@ namespace UnitTestEx.Azure.Functions
 
         private readonly bool? _includeUnitTestConfiguration;
         private readonly bool? _includeUserSecrets;
-        private readonly IEnumerable<KeyValuePair<string, string?>>? _additionalConfiguration;
         private IHost? _host;
         private bool _disposed;
 
@@ -62,7 +61,7 @@ namespace UnitTestEx.Azure.Functions
             Logger = LoggerProvider.CreateLogger(GetType().Name);
             _includeUnitTestConfiguration = includeUnitTestConfiguration;
             _includeUserSecrets = includeUserSecrets;
-            _additionalConfiguration = additionalConfiguration;
+            AdditionalConfiguration = additionalConfiguration;
         }
 
         /// <summary>
@@ -168,8 +167,8 @@ namespace UnitTestEx.Azure.Functions
                         if (!_includeUnitTestConfiguration.HasValue && TestSetUp.FunctionTesterIncludeUnitTestConfiguration || _includeUnitTestConfiguration.HasValue && _includeUnitTestConfiguration.Value)
                             cb.AddJsonFile("appsettings.unittest.json", optional: true);
 
-                        if (_additionalConfiguration != null)
-                            cb.AddInMemoryCollection(_additionalConfiguration);
+                        if (AdditionalConfiguration != null)
+                            cb.AddInMemoryCollection(AdditionalConfiguration);
                     })
                     .ConfigureServices(sc =>
                     {

--- a/src/UnitTestEx.Azure.Functions/UnitTestEx.Azure.Functions.csproj
+++ b/src/UnitTestEx.Azure.Functions/UnitTestEx.Azure.Functions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>UnitTestEx</RootNamespace>
     <Product>UnitTestEx</Product>
     <Title>UnitTestEx Azure Functions Test Extensions.</Title>

--- a/src/UnitTestEx.Azure.ServiceBus/UnitTestEx.Azure.ServiceBus.csproj
+++ b/src/UnitTestEx.Azure.ServiceBus/UnitTestEx.Azure.ServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>UnitTestEx</RootNamespace>
     <Product>UnitTestEx</Product>
     <Title>UnitTestEx Azure Functions Test Extensions.</Title>

--- a/src/UnitTestEx.MSTest/UnitTestEx.MSTest.csproj
+++ b/src/UnitTestEx.MSTest/UnitTestEx.MSTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>UnitTestEx.MSTest</RootNamespace>
 	  <Product>UnitTestEx MSTest</Product>
 	  <Title>UnitTestEx MSTest Test Extensions.</Title>

--- a/src/UnitTestEx.NUnit/UnitTestEx.NUnit.csproj
+++ b/src/UnitTestEx.NUnit/UnitTestEx.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>UnitTestEx.NUnit</RootNamespace>
 	  <Product>UnitTestEx NUnit</Product>
 	  <Title>UnitTestEx NUnit Test Extensions.</Title>

--- a/src/UnitTestEx.Xunit/UnitTestEx.Xunit.csproj
+++ b/src/UnitTestEx.Xunit/UnitTestEx.Xunit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>UnitTestEx.Xunit</RootNamespace>
 	  <Product>UnitTestEx Xunit</Product>
 	  <Title>UnitTestEx Xunit Test Extensions.</Title>

--- a/src/UnitTestEx/Abstractions/TesterBase.cs
+++ b/src/UnitTestEx/Abstractions/TesterBase.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnitTestEx.Json;
 using UnitTestEx.Logging;
 
@@ -18,6 +19,7 @@ namespace UnitTestEx.Abstractions
     {
         private string? _userName;
         private readonly List<Action<IServiceCollection>> _configureServices = [];
+        private IEnumerable<KeyValuePair<string, string?>>? _additionalConfiguration;
 
         /// <summary>
         /// Static constructor.
@@ -95,6 +97,19 @@ namespace UnitTestEx.Abstractions
         {
             get => _userName ?? SetUp.DefaultUserName;
             protected set => _userName = value;
+        }
+
+        /// <summary>
+        /// Gets the additional configuration used at host initialization (see <see cref="MemoryConfigurationBuilderExtensions.AddInMemoryCollection(IConfigurationBuilder, IEnumerable{KeyValuePair{string, string}})"/>).
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string?>>? AdditionalConfiguration
+        {
+            get => _additionalConfiguration?.ToArray();
+            protected set
+            {
+                _additionalConfiguration = value;
+                ResetHost(false);
+            }
         }
 
         /// <summary>
@@ -182,7 +197,7 @@ namespace UnitTestEx.Abstractions
         protected void AddConfiguredServices(IServiceCollection services)
         {
             if (IsHostInstantiated)
-                throw new InvalidOperationException($"Underlying host has been instantiated and as such the {nameof(ConfigureServices)} operations can no longer be used.");
+                throw new InvalidOperationException($"Underlying host has been instantiated and as such the {nameof(ConfigureServices)} operations can no longer be used; consider using '{nameof(ResetHost)}' prior to enable.");
 
             foreach (var configureService in _configureServices)
             {

--- a/src/UnitTestEx/Abstractions/TesterBaseT.cs
+++ b/src/UnitTestEx/Abstractions/TesterBaseT.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System;
+using System.Collections.Generic;
 using UnitTestEx.Json;
 
 namespace UnitTestEx.Abstractions
@@ -89,6 +91,27 @@ namespace UnitTestEx.Abstractions
             JsonComparerOptions = options ?? throw new ArgumentNullException(nameof(options));
             return (TSelf)this;
         }
+
+        /// <summary>
+        /// Updates (replaces) the <see cref="TesterBase.AdditionalConfiguration"/> (see <see cref="MemoryConfigurationBuilderExtensions.AddInMemoryCollection(IConfigurationBuilder, IEnumerable{KeyValuePair{string, string}})"/>).
+        /// </summary>
+        /// <param name="additionalConfiguration">The additional configuration key/value pairs.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        /// <remarks>Usage will result in a <see cref="TesterBase.ResetHost()"/>.</remarks>
+        public TSelf UseAdditionalConfiguration(IEnumerable<KeyValuePair<string, string?>>? additionalConfiguration)
+        {
+            AdditionalConfiguration = additionalConfiguration;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Updates (replaces) the <see cref="TesterBase.AdditionalConfiguration"/> (see <see cref="MemoryConfigurationBuilderExtensions.AddInMemoryCollection(IConfigurationBuilder, IEnumerable{KeyValuePair{string, string}})"/>) with specified <paramref name="key"/> and <paramref name="value"/>.
+        /// </summary>
+        /// <param name="key">The additional configuration key.</param>
+        /// <param name="value">The additional configuration value.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        /// <remarks>Usage will result in a <see cref="TesterBase.ResetHost()"/>.</remarks>
+        public TSelf UseAdditionalConfiguration(string key, string? value) => UseAdditionalConfiguration([new KeyValuePair<string, string?>(key, value)]);
 
         /// <summary>
         /// Resets the underlying host to instantiate a new instance.

--- a/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
@@ -61,7 +61,12 @@ namespace UnitTestEx.AspNetCore
 
                 return _waf = new WebApplicationFactory<TEntryPoint>().WithWebHostBuilder(whb =>
                     whb.UseSolutionRelativeContentRoot(Environment.CurrentDirectory)
-                        .ConfigureAppConfiguration((_, x) => x.AddJsonFile("appsettings.unittest.json", optional: true))
+                        .ConfigureAppConfiguration((_, cb) =>
+                        {
+                            cb.AddJsonFile("appsettings.unittest.json", optional: true);
+                            if (AdditionalConfiguration != null)
+                                cb.AddInMemoryCollection(AdditionalConfiguration);
+                        })
                         .ConfigureServices(sc =>
                         {
                             sc.AddHttpContextAccessor();

--- a/src/UnitTestEx/Generic/GenericTesterCore.cs
+++ b/src/UnitTestEx/Generic/GenericTesterCore.cs
@@ -67,6 +67,9 @@ namespace UnitTestEx.Generic
                         ep.ConfigureAppConfiguration(hbc, cb);
                         cb.AddJsonFile("appsettings.unittest.json", optional: true)
                           .AddEnvironmentVariables();
+
+                        if (AdditionalConfiguration != null)
+                            cb.AddInMemoryCollection(AdditionalConfiguration);
                     })
                     .ConfigureServices(sc =>
                     {

--- a/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
@@ -50,6 +51,16 @@ namespace UnitTestEx.NUnit.Test.Other
 
             test.Run<Gin>(gin => gin.StirAsync())
                 .AssertException<DivideByZeroException>("As required by Bond; shaken, not stirred.");
+        }
+
+        [Test]
+        public void Configuration_Overrride_Use()
+        {
+            // Demonstrates how to override the configuration settings for a test.
+            using var test = GenericTester.Create();
+            test.UseAdditionalConfiguration([new("SpecialKey", "NotSoSpecial")]);
+            var cv = test.Configuration.GetValue<string>("SpecialKey");
+            Assert.That(cv, Is.EqualTo("NotSoSpecial"));
         }
     }
 

--- a/tests/UnitTestEx.NUnit.Test/ProductControllerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/ProductControllerTest.cs
@@ -102,6 +102,21 @@ namespace UnitTestEx.NUnit.Test
         }
 
         [Test]
+        public void Configuration_Use()
+        {
+            using var test = ApiTester.Create<Startup>();
+            test.UseAdditionalConfiguration("SpecialKey", "NotSoSpecial");
+
+            var cv = test.Configuration.GetValue<string>("SpecialKey");
+            Assert.That(cv, Is.EqualTo("NotSoSpecial"));
+
+            // Null to reset.
+            test.UseAdditionalConfiguration(null);
+            cv = test.Configuration.GetValue<string>("SpecialKey");
+            Assert.That(cv, Is.EqualTo("VerySpecialValue"));
+        }
+
+        [Test]
         public void DefaultHttpClient()
         {
             var mcf = MockHttpClientFactory.Create();

--- a/tests/UnitTestEx.NUnit.Test/ServiceBusFunctionTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/ServiceBusFunctionTest.cs
@@ -151,5 +151,15 @@ namespace UnitTestEx.NUnit.Test
             var cv = test.Configuration.GetValue<string>("SpecialKey");
             Assert.That(cv, Is.EqualTo("NotSoSpecial"));
         }
+
+        [Test]
+        public void Configuration_Overrride_Use()
+        {
+            // Demonstrates how to override the configuration settings for a test.
+            using var test = FunctionTester.Create<Startup>();
+            test.UseAdditionalConfiguration([new("SpecialKey", "NotSoSpecial")]);
+            var cv = test.Configuration.GetValue<string>("SpecialKey");
+            Assert.That(cv, Is.EqualTo("NotSoSpecial"));
+        }
     }
 }


### PR DESCRIPTION
- *Enhancement:* Added `TesterBase<TSelf>.UseAdditionalConfiguration` method to enable additional configuration to be specified that overrides the `IHostBuilder` as the host is being built. This leverages the underlying `IConfigurationBuilder.AddInMemoryCollection` capability to add. This is intended to support additional configuration that is not part of the standard `appsettings.json` or `appsettings.unittest.json` configuration.