### PR TITLE
V5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v5.3.0
+- *Enhancement:* Added `MockHttpClientResponse.Header` methods to enable the specification of headers to be included in the mocked response.
+  - The `MockHttpClient.WithRequestsFromResource` YAML/JSON updated to also support the specification of response headers.   
+
 ## v5.2.0
 - *Enhancement:* Added `TesterBase<TSelf>.UseAdditionalConfiguration` method to enable additional configuration to be specified that overrides the `IHostBuilder` as the host is being built. This leverages the underlying `IConfigurationBuilder.AddInMemoryCollection` capability to add. This is intended to support additional configuration that is not part of the standard `appsettings.json` or `appsettings.unittest.json` configuration.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.2.0</Version>
+		<Version>5.3.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ The following represents a YAML example for one-to-one request/responses:
 - method: get
   uri: people/123
   response:
+    headers:
+      ETag: Abc123
     body: |
       {
         "first":"Bob",

--- a/src/UnitTestEx/Mocking/MockHttpClient.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClient.cs
@@ -440,12 +440,21 @@ namespace UnitTestEx.Mocking
             public HttpStatusCode? Status { get; set; }
             public string? Body { get; set; }
             public string? Media { get; set; }
+            public Dictionary<string, string?[]>? Headers { get; set; }
 
             /// <summary>
             /// Adds the response.
             /// </summary>
             public void Add(MockHttpClientResponse res)
             {
+                if (Headers is not null)
+                {
+                    foreach (var header in Headers)
+                    {
+                        res.Header(header.Key, header.Value);
+                    }
+                }
+
                 if (string.IsNullOrEmpty(Body))
                 {
                     res.With(Status ?? HttpStatusCode.NoContent);

--- a/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
@@ -123,6 +123,14 @@ namespace UnitTestEx.Mocking
             if (response.Content != null)
                 httpResponse.Content = response.Content;
 
+            if (!response.HttpHeaders.IsEmpty)
+            {
+                foreach (var header in response.HttpHeaders)
+                {
+                    httpResponse.Headers.Add(header.Key, header.Value);
+                }
+            }
+
             await response.ExecuteDelayAsync(ct).ConfigureAwait(false);
 
             response.ResponseAction?.Invoke(httpResponse);

--- a/src/UnitTestEx/Mocking/MockHttpClientResponse.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientResponse.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
@@ -60,6 +62,11 @@ namespace UnitTestEx.Mocking
         internal int Count { get; set; }
 
         /// <summary>
+        /// Gets the response headers.
+        /// </summary>
+        internal ConcurrentDictionary<string, List<string?>> HttpHeaders { get; } = [];
+
+        /// <summary>
         /// Sets the simulated delay (sleep) for the response.
         /// </summary>
         /// <param name="timeSpan">The delay (sleep) function.</param>
@@ -110,6 +117,42 @@ namespace UnitTestEx.Mocking
         /// <returns>The <see cref="MockHttpClientResponse"/> to support fluent-style method-chaining.</returns>
         /// <remarks>Each time a <c>Delay</c> is invoked it will override the previously set value.</remarks>
         public MockHttpClientResponse Delay(int from, int to) => Delay(TimeSpan.FromMilliseconds(from), TimeSpan.FromMilliseconds(to));
+
+        /// <summary>
+        /// Adds the specified headers and values for the response.
+        /// </summary>
+        /// <param name="headers">The headers collection.</param>
+        /// <returns>The <see cref="MockHttpClientResponse"/> to support fluent-style method-chaining.</returns>
+        public MockHttpClientResponse Headers(IEnumerable<KeyValuePair<string, string?>> headers)
+        {
+            foreach (var header in headers)
+            {
+                Header(header.Key, header.Value);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the specified header and its value for the response.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="value">The header value.</param>
+        /// <returns>The <see cref="MockHttpClientResponse"/> to support fluent-style method-chaining.</returns>
+        public MockHttpClientResponse Header(string name, string? value) => Header(name, [value]);
+
+        /// <summary>
+        /// Adds the specified header and its values for the response.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="values">The header values.</param>
+        /// <returns>The <see cref="MockHttpClientResponse"/> to support fluent-style method-chaining.</returns>
+        public MockHttpClientResponse Header(string name, IEnumerable<string?> values)
+        {
+            var h = HttpHeaders.GetOrAdd(name, _ => []);
+            h.AddRange(values);
+            return this;
+        }
 
         /// <summary>
         /// Provides the mocked response.

--- a/src/UnitTestEx/Schema/mock.unittestex.json
+++ b/src/UnitTestEx/Schema/mock.unittestex.json
@@ -61,6 +61,10 @@
           "title": "The HTTP Response status code.",
           "description": "Defaults to 200-OK where there is a corresponding Body; otherwise, 204-No content."
         },
+        "headers": {
+          "$ref": "#/definitions/MockResponseHeaders",
+          "title": "The HTTP Response headers configuration."
+        },
         "body": {
           "type": "string",
           "title": "The HTTP Response body (content)."
@@ -71,9 +75,19 @@
           "description": "Defaults to 'application/json' where the Body contains JSON; otherwise, 'text/plain'."
         }
       }
+    },
+    "MockResponseHeaders": {
+      "title": "The HTTP Response headers configuration.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "items": {
+      "$ref": "#/definitions/MockRequest"
     }
-  },
-  "items": {
-    "$ref": "#/definitions/MockRequest"
   }
 }

--- a/tests/UnitTestEx.NUnit.Test/Resources/mock.unittestex.yaml
+++ b/tests/UnitTestEx.NUnit.Test/Resources/mock.unittestex.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=C:\Repos\UnitTestEx\src\UnitTestEx\Schema\mock.unittestex.json
 - method: post
   uri: products/xyz
   body: ^
@@ -9,6 +10,9 @@
 - method: get
   uri: people/123
   response:
+    headers:
+      Age: [ '55' ]
+      x-blah: [ abc ]
     body: |
       {
         "first":"Bob",

--- a/tests/UnitTestEx.NUnit.Test/Resources/mock.unittestex.yaml
+++ b/tests/UnitTestEx.NUnit.Test/Resources/mock.unittestex.yaml
@@ -4,8 +4,6 @@
   body: ^
   response:
     status: 202
-    headers:
-      Content-Type: [ 'application/json' ]
     body: |
       {"product":"xyz","quantity":1}
 

--- a/tests/UnitTestEx.NUnit.Test/Resources/mock.unittestex.yaml
+++ b/tests/UnitTestEx.NUnit.Test/Resources/mock.unittestex.yaml
@@ -1,9 +1,11 @@
-# yaml-language-server: $schema=C:\Repos\UnitTestEx\src\UnitTestEx\Schema\mock.unittestex.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Avanade/UnitTestEx/refs/heads/main/src/UnitTestEx/Schema/mock.unittestex.json
 - method: post
   uri: products/xyz
   body: ^
   response:
     status: 202
+    headers:
+      Content-Type: [ 'application/json' ]
     body: |
       {"product":"xyz","quantity":1}
 


### PR DESCRIPTION
- *Enhancement:* Added `MockHttpClientResponse.Header` methods to enable the specification of headers to be included in the mocked response.
  - The `MockHttpClient.WithRequestsFromResource` YAML/JSON updated to also support the specification of response headers. 