### PR TITLE
v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v5.4.0
+- *Enhancement:* All `CreateHttpRequest` and related methods moved to `TesterBase` to ensure availability for all derived testers.
+- *Enhancement:* Added `ToHttpResponseMessageAssertor` to `ActionResultAssertor` and `ValueAssertor` that converts an `IActionResult` to an `HttpResponseMessage` and returns an `HttpResponseMessageAssertor` for further assertions. The underlying `Host` must be configured (DI) correctly for this to function; otherwise, an exception will be thrown.
+- *Enhancement:* Added `WithApiTester` base class per test framework to provide a shared `ApiTester` instance per test class; versus instantiating per test method. Be aware that using may result in cross-test contamination.
+
 ## v5.3.0
 - *Enhancement:* Added `MockHttpClientResponse.Header` methods to enable the specification of headers to be included in the mocked response.
   - The `MockHttpClient.WithRequestsFromResource` YAML/JSON updated to also support the specification of response headers.   

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.3.0</Version>
+		<Version>5.4.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx.MSTest/WithApiTester.cs
+++ b/src/UnitTestEx.MSTest/WithApiTester.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
+
+using System;
+using UnitTestEx.AspNetCore;
+
+namespace UnitTestEx
+{
+    /// <summary>
+    /// Provides a shared <see cref="Test"/> <see cref="ApiTester{TEntryPoint}"/> to enable usage of the same underlying <see cref="ApiTesterBase{TEntryPoint, TSelf}.GetTestServer"/> instance across multiple tests.
+    /// </summary>
+    /// <typeparam name="TEntryPoint">The API startup <see cref="Type"/>.</typeparam>
+    /// <remarks>Implements <see cref="IDisposable"/> to automatically dispose of the <see cref="Test"/> instance to release all resources.
+    /// <para>Be aware that using may result in cross-test contamination.</para></remarks>
+    public abstract class WithApiTester<TEntryPoint> : IDisposable where TEntryPoint : class
+    {
+        private bool _disposed;
+        private ApiTester<TEntryPoint>? _apiTester = ApiTester.Create<TEntryPoint>();
+
+        /// <summary>
+        /// Gets the shared <see cref="ApiTester{TEntryPoint}"/> for testing.
+        /// </summary>
+        public ApiTester<TEntryPoint> Test => _apiTester ?? throw new ObjectDisposedException(nameof(Test));
+
+        /// <summary>
+        /// Dispose of all resources.
+        /// </summary>
+        /// <param name="disposing">Indicates whether from the <see cref="Dispose()"/>.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _apiTester?.Dispose();
+                    _apiTester = null;
+                }
+
+                _disposed = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/UnitTestEx.NUnit/WithApiTester.cs
+++ b/src/UnitTestEx.NUnit/WithApiTester.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
+
+using System;
+using UnitTestEx.AspNetCore;
+
+namespace UnitTestEx
+{
+    /// <summary>
+    /// Provides a shared <see cref="Test"/> <see cref="ApiTester{TEntryPoint}"/> to enable usage of the same underlying <see cref="ApiTesterBase{TEntryPoint, TSelf}.GetTestServer"/> instance across multiple tests.
+    /// </summary>
+    /// <typeparam name="TEntryPoint">The API startup <see cref="Type"/>.</typeparam>
+    /// <remarks>Implements <see cref="IDisposable"/> to automatically dispose of the <see cref="Test"/> instance to release all resources.
+    /// <para>Be aware that using may result in cross-test contamination.</para></remarks>
+    public abstract class WithApiTester<TEntryPoint> : IDisposable where TEntryPoint : class
+    {
+        private bool _disposed;
+        private ApiTester<TEntryPoint>? _apiTester = ApiTester.Create<TEntryPoint>();
+
+        /// <summary>
+        /// Gets the shared <see cref="ApiTester{TEntryPoint}"/> for testing.
+        /// </summary>
+        public ApiTester<TEntryPoint> Test => _apiTester ?? throw new ObjectDisposedException(nameof(Test));
+
+        /// <summary>
+        /// Dispose of all resources.
+        /// </summary>
+        /// <param name="disposing">Indicates whether from the <see cref="Dispose()"/>.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _apiTester?.Dispose();
+                    _apiTester = null;
+                }
+
+                _disposed = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/UnitTestEx.Xunit/ApiTestFixture.cs
+++ b/src/UnitTestEx.Xunit/ApiTestFixture.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
+
+using System;
+using UnitTestEx.AspNetCore;
+using UnitTestEx.Xunit.Internal;
+
+namespace UnitTestEx
+{
+    /// <summary>
+    /// Provides a shared <see cref="Test"/> <see cref="ApiTester{TEntryPoint}"/> to enable usage of the same underlying <see cref="ApiTesterBase{TEntryPoint, TSelf}.GetTestServer"/> instance across multiple tests.
+    /// </summary>
+    /// <remarks>Be aware that using may result in cross-test contamination.</remarks>
+    public sealed class ApiTestFixture<TEntryPoint> : IDisposable where TEntryPoint : class
+    {
+        private ApiTester<TEntryPoint>? _apiTester = ApiTester.Create<TEntryPoint>(() => new XunitLocalTestImplementor());
+
+        /// <summary>
+        /// Gets the shared <see cref="ApiTester{TEntryPoint}"/> for testing.
+        /// </summary>
+        public ApiTester<TEntryPoint> Test => _apiTester ?? throw new ObjectDisposedException(nameof(Test));
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _apiTester?.Dispose();
+            _apiTester = null;
+        }
+    }
+}

--- a/src/UnitTestEx.Xunit/Internal/XunitLocalTestImplementor.cs
+++ b/src/UnitTestEx.Xunit/Internal/XunitLocalTestImplementor.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
+
+using System.Threading;
+
+namespace UnitTestEx.Xunit.Internal
+{
+    /// <summary>
+    /// Provides a <see cref="AsyncLocal{T}"/>-based proxy to an <see cref="XunitTestImplementor"/> instance.
+    /// </summary>
+    public sealed class XunitLocalTestImplementor() : Abstractions.TestFrameworkImplementor
+    {
+        private static readonly AsyncLocal<XunitTestImplementor?> _localImplementor = new();
+
+        /// <summary>
+        /// Sets the <see cref="AsyncLocal{T}"/> <see cref="XunitTestImplementor"/>.
+        /// </summary>
+        /// <param name="implementor">The <see cref="XunitTestImplementor"/>.</param>
+        internal static void SetLocalImplementor(XunitTestImplementor implementor) => _localImplementor.Value = implementor;
+
+        /// <summary>
+        /// Gets the <see cref="AsyncLocal{T}"/> <see cref="XunitTestImplementor"/>.
+        /// </summary>
+        private static XunitTestImplementor? Implementor => _localImplementor.Value;
+
+        /// <inheritdoc/>
+        public override void AssertAreEqual<T>(T? expected, T? actual, string? message = null) where T : default => Implementor?.AssertAreEqual(expected, actual, message);
+
+        /// <inheritdoc/>
+        public override void AssertFail(string? message) => Implementor?.AssertFail(message);
+
+        /// <inheritdoc/>
+        public override void AssertInconclusive(string? message) => Implementor?.AssertInconclusive(message);
+
+        /// <inheritdoc/>
+        public override void WriteLine(string? message) => Implementor?.WriteLine(message);
+    }
+}

--- a/src/UnitTestEx.Xunit/Internal/XunitTestImplementor.cs
+++ b/src/UnitTestEx.Xunit/Internal/XunitTestImplementor.cs
@@ -28,7 +28,17 @@ namespace UnitTestEx.Xunit.Internal
         public override void AssertFail(string? message) => throw new XunitException(message ?? _notSpecifiedText);
 
         /// <inheritdoc/>
-        public override void AssertAreEqual<T>(T? expected, T? actual, string? message = null) where T : default => Assert.Equal(expected, actual);
+        public override void AssertAreEqual<T>(T? expected, T? actual, string? message = null) where T : default
+        {
+            try
+            {
+                Assert.Equal(expected, actual);
+            }
+            catch (XunitException ex)
+            {
+                throw new XunitException(message is null ? ex.Message : $"{message}{Environment.NewLine}{ex.Message}", ex);
+            }
+        }
 
         /// <inheritdoc/>
         public override void AssertInconclusive(string? message) => AssertFail($"Inconclusive: {message}");

--- a/src/UnitTestEx.Xunit/UnitTestBase.cs
+++ b/src/UnitTestEx.Xunit/UnitTestBase.cs
@@ -5,7 +5,7 @@ using UnitTestEx.Abstractions;
 using UnitTestEx.Xunit.Internal;
 using Xunit.Abstractions;
 
-namespace UnitTestEx.Xunit
+namespace UnitTestEx
 {
     /// <summary>
     /// Provides the base <b>Xunit</b> capabilities.

--- a/src/UnitTestEx.Xunit/WithApiTester.cs
+++ b/src/UnitTestEx.Xunit/WithApiTester.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
+
+using System;
+using UnitTestEx.AspNetCore;
+using UnitTestEx.Xunit.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace UnitTestEx
+{
+    /// <summary>
+    /// Provides a shared <see cref="Test"/> <see cref="ApiTester{TEntryPoint}"/> to enable usage of the same underlying <see cref="ApiTesterBase{TEntryPoint, TSelf}.GetTestServer"/> instance across multiple tests.
+    /// </summary>
+    /// <typeparam name="TEntryPoint">The API startup <see cref="Type"/>.</typeparam>
+    /// <remarks>Implements <see cref="IDisposable"/> to automatically dispose of the <see cref="Test"/> instance to release all resources.
+    /// <para>Be aware that using may result in cross-test contamination.</para></remarks>
+    public abstract class WithApiTester<TEntryPoint> : UnitTestBase, IClassFixture<ApiTestFixture<TEntryPoint>> where TEntryPoint : class
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WithApiTester{TEntryPoint}"/> class.
+        /// </summary>
+        /// <param name="fixture">The shared <see cref="ApiTestFixture{TEntryPoint}"/>.</param>
+        /// <param name="output">The <see cref="ITestOutputHelper"/>.</param>
+        public WithApiTester(ApiTestFixture<TEntryPoint> fixture, ITestOutputHelper output) : base(output)
+        {
+            Test = fixture.Test;
+            XunitLocalTestImplementor.SetLocalImplementor(new XunitTestImplementor(output));
+        }
+
+        /// <summary>
+        /// Gets the shared <see cref="ApiTester{TEntryPoint}"/> for testing.
+        /// </summary>
+        public ApiTester<TEntryPoint> Test { get; }
+    }
+}

--- a/src/UnitTestEx/Abstractions/TestFrameworkImplementor.cs
+++ b/src/UnitTestEx/Abstractions/TestFrameworkImplementor.cs
@@ -52,10 +52,14 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Creates a new instance of the <see cref="TestFrameworkImplementor"/> (see <see cref="SetGlobalCreateFactory"/> or <see cref="SetLocalCreateFactory"/>).
         /// </summary>
+        /// <param name="createFactory">The optional function to create the <see cref="TestFrameworkImplementor"/> instance.</param>
         /// <returns>The new instance of the <see cref="TestFrameworkImplementor"/>.</returns>
-        public static TestFrameworkImplementor Create()
+        public static TestFrameworkImplementor Create(Func<TestFrameworkImplementor>? createFactory = null)
         {
             TestSetUp.Force();
+
+            if (createFactory is not null)
+                return createFactory() ?? throw new InvalidOperationException($"The {nameof(createFactory)} has returned null.");
 
             if (_localCreateFactory.Value is not null)
                 return _localCreateFactory.Value.Invoke() ?? throw new InvalidOperationException($"The {nameof(TestFrameworkImplementor)}.{nameof(SetLocalCreateFactory)} has returned null.");

--- a/src/UnitTestEx/ApiTester.cs
+++ b/src/UnitTestEx/ApiTester.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
 using System;
+using UnitTestEx.Abstractions;
 using UnitTestEx.AspNetCore;
 
 namespace UnitTestEx
@@ -14,7 +15,8 @@ namespace UnitTestEx
         /// Creates a new instance of the <see cref="ApiTester{TEntryPoint}"/> class.
         /// </summary>
         /// <typeparam name="TEntryPoint">The API startup <see cref="Type"/>.</typeparam>
+        /// <param name="createFactory">The optional function to create the <see cref="TestFrameworkImplementor"/> instance.</param>
         /// <returns>The <see cref="ApiTester{TEntryPoint}"/>.</returns>
-        public static ApiTester<TEntryPoint> Create<TEntryPoint>() where TEntryPoint : class => new();
+        public static ApiTester<TEntryPoint> Create<TEntryPoint>(Func<TestFrameworkImplementor>? createFactory = null) where TEntryPoint : class => new(createFactory);
     }
 }

--- a/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
@@ -54,6 +54,9 @@ namespace UnitTestEx.AspNetCore
         /// </summary>
         protected WebApplicationFactory<TEntryPoint> GetWebApplicationFactory()
         {
+            if (_waf != null)
+                return _waf;
+
             lock (SyncRoot)
             {
                 if (_waf != null)
@@ -84,7 +87,18 @@ namespace UnitTestEx.AspNetCore
         }
 
         /// <inheritdoc/>
-        protected override void ResetHost() => _waf = null;
+        protected override void ResetHost()
+        {
+            lock (SyncRoot)
+            {
+                if (_waf is not null)
+                {
+                    _waf.Dispose();
+                    _waf = null;
+                    Implementor.WriteLine("The underlying UnitTestEx 'ApiTester' Host has been reset.");
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the <see cref="IServiceProvider"/> from the underlying host.

--- a/src/UnitTestEx/AspNetCore/ApiTesterT.cs
+++ b/src/UnitTestEx/AspNetCore/ApiTesterT.cs
@@ -9,5 +9,6 @@ namespace UnitTestEx.AspNetCore
     /// Provides the concrete <see cref="ApiTesterBase{TEntryPoint, TSelf}"/> implementation.
     /// </summary>
     /// <typeparam name="TEntryPoint">The API startup <see cref="Type"/>.</typeparam>
-    public class ApiTester<TEntryPoint>() : ApiTesterBase<TEntryPoint, ApiTester<TEntryPoint>>(TestFrameworkImplementor.Create()) where TEntryPoint : class { }
+    /// <param name="createFactory">The optional function to create the <see cref="TestFrameworkImplementor"/> instance.</param>
+    public class ApiTester<TEntryPoint>(Func<TestFrameworkImplementor>? createFactory = null) : ApiTesterBase<TEntryPoint, ApiTester<TEntryPoint>>(TestFrameworkImplementor.Create(createFactory)) where TEntryPoint : class { }
 }

--- a/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
@@ -312,44 +312,7 @@ namespace UnitTestEx.AspNetCore
             if (res.RequestMessage == null)
                 return;
 
-            Implementor.WriteLine("");
-            Implementor.WriteLine($"RESPONSE >");
-            Implementor.WriteLine($"HttpStatusCode: {res.StatusCode} ({(int)res.StatusCode})");
-            Implementor.WriteLine($"Elapsed (ms): {(sw == null ? "none" : sw.Elapsed.TotalMilliseconds.ToString(System.Globalization.CultureInfo.InvariantCulture))}");
-
-            var hdrs = res.Headers?.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-            Implementor.WriteLine($"Headers: {(hdrs == null || hdrs.Length == 0 ? "none" : "")}");
-            if (hdrs != null && hdrs.Length > 0)
-            {
-                foreach (var hdr in hdrs)
-                {
-                    Implementor.WriteLine($"  {hdr}");
-                }
-            }
-
-            object? jo = null;
-            var content = res.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-            if (!string.IsNullOrEmpty(content) && res.Content?.Headers?.ContentType?.MediaType == MediaTypeNames.Application.Json)
-            {
-                try
-                {
-                    jo = JsonSerializer.Deserialize(content);
-                }
-                catch (Exception) { /* This is being swallowed by design. */ }
-            }
-
-            var txt = $"Content: [{res.Content?.Headers?.ContentType?.MediaType ?? "none"}]";
-            if (jo != null)
-            {
-                Implementor.WriteLine(txt);
-                Implementor.WriteLine(JsonSerializer.Serialize(jo, JsonWriteFormat.Indented));
-            }
-            else
-                Implementor.WriteLine($"{txt} {(string.IsNullOrEmpty(content) ? "none" : content)}");
-
-            Implementor.WriteLine("");
-            Implementor.WriteLine(new string('=', 80));
-            Implementor.WriteLine("");
+            Owner.LogHttpResponseMessage(res, sw);
         }
 
         /// <summary>

--- a/src/UnitTestEx/AspNetCore/HttpTesterT.cs
+++ b/src/UnitTestEx/AspNetCore/HttpTesterT.cs
@@ -25,11 +25,11 @@ namespace UnitTestEx.AspNetCore
         /// <param name="httpMethod">The <see cref="HttpMethod"/></param>
         /// <param name="requestUri">The string that represents the request <see cref="Uri"/>.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequestMessage"/> modifier.</param>
-        /// <returns>An <see cref="HttpResponseMessageAssertor"/>.</returns>
+        /// <returns>An <see cref="HttpResponseMessageAssertor{TValue}"/>.</returns>
 #if NET7_0_OR_GREATER
-        public HttpResponseMessageAssertor Run(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Action<HttpRequestMessage>? requestModifier = null)
+        public HttpResponseMessageAssertor<TValue> Run(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Action<HttpRequestMessage>? requestModifier = null)
 #else
-        public HttpResponseMessageAssertor Run(HttpMethod httpMethod, string? requestUri, Action<HttpRequestMessage>? requestModifier = null)
+        public HttpResponseMessageAssertor<TValue> Run(HttpMethod httpMethod, string? requestUri, Action<HttpRequestMessage>? requestModifier = null)
 #endif
             => RunAsync(httpMethod, requestUri, requestModifier).GetAwaiter().GetResult();
 
@@ -41,11 +41,11 @@ namespace UnitTestEx.AspNetCore
         /// <param name="body">The optional body content.</param>
         /// <param name="contentType">The content type. Defaults to <see cref="MediaTypeNames.Text.Plain"/>.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequestMessage"/> modifier.</param>
-        /// <returns>An <see cref="HttpResponseMessageAssertor"/>.</returns>
+        /// <returns>An <see cref="HttpResponseMessageAssertor{TValue}"/>.</returns>
 #if NET7_0_OR_GREATER
-        public HttpResponseMessageAssertor Run(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, string? body, string? contentType = MediaTypeNames.Text.Plain, Action<HttpRequestMessage>? requestModifier = null)
+        public HttpResponseMessageAssertor<TValue> Run(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, string? body, string? contentType = MediaTypeNames.Text.Plain, Action<HttpRequestMessage>? requestModifier = null)
 #else
-        public HttpResponseMessageAssertor Run(HttpMethod httpMethod, string? requestUri, string? body, string? contentType = MediaTypeNames.Text.Plain, Action<HttpRequestMessage>? requestModifier = null)
+        public HttpResponseMessageAssertor<TValue> Run(HttpMethod httpMethod, string? requestUri, string? body, string? contentType = MediaTypeNames.Text.Plain, Action<HttpRequestMessage>? requestModifier = null)
 #endif
             => RunAsync(httpMethod, requestUri, body, contentType, requestModifier).GetAwaiter().GetResult();
 
@@ -56,13 +56,13 @@ namespace UnitTestEx.AspNetCore
         /// <param name="requestUri">The string that represents the request <see cref="Uri"/>.</param>
         /// <param name="value">The request body value.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequestMessage"/> modifier.</param>
-        /// <returns>An <see cref="HttpResponseMessageAssertor"/>.</returns>
+        /// <returns>An <see cref="HttpResponseMessageAssertor{TValue}"/>.</returns>
 #if NET7_0_OR_GREATER
-        public HttpResponseMessageAssertor Run<T>(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, T? value, Action<HttpRequestMessage>? requestModifier = null)
+        public HttpResponseMessageAssertor<TValue> Run<T>(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, T? value, Action<HttpRequestMessage>? requestModifier = null)
 #else
-        public HttpResponseMessageAssertor Run<T>(HttpMethod httpMethod, string? requestUri, T? value, Action<HttpRequestMessage>? requestModifier = null)
+        public HttpResponseMessageAssertor<TValue> Run<T>(HttpMethod httpMethod, string? requestUri, T? value, Action<HttpRequestMessage>? requestModifier = null)
 #endif
-            => SendAsync(httpMethod, requestUri, value, requestModifier).GetAwaiter().GetResult();
+            => new(SendAsync(httpMethod, requestUri, value, requestModifier).GetAwaiter().GetResult());
 
         /// <summary>
         /// Runs the test by sending an <see cref="HttpRequestMessage"/> with no body.
@@ -70,13 +70,13 @@ namespace UnitTestEx.AspNetCore
         /// <param name="httpMethod">The <see cref="HttpMethod"/></param>
         /// <param name="requestUri">The string that represents the request <see cref="Uri"/>.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequestMessage"/> modifier.</param>
-        /// <returns>An <see cref="HttpResponseMessageAssertor"/>.</returns>
+        /// <returns>An <see cref="HttpResponseMessageAssertor{TValue}"/>.</returns>
 #if NET7_0_OR_GREATER
-        public Task<HttpResponseMessageAssertor> RunAsync(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Action<HttpRequestMessage>? requestModifier = null)
+        public async Task<HttpResponseMessageAssertor<TValue>> RunAsync(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Action<HttpRequestMessage>? requestModifier = null)
 #else
-        public Task<HttpResponseMessageAssertor> RunAsync(HttpMethod httpMethod, string? requestUri, Action<HttpRequestMessage>? requestModifier = null)
+        public async Task<HttpResponseMessageAssertor<TValue>> RunAsync(HttpMethod httpMethod, string? requestUri, Action<HttpRequestMessage>? requestModifier = null)
 #endif
-            => SendAsync(httpMethod, requestUri, requestModifier);
+            => new(await SendAsync(httpMethod, requestUri, requestModifier).ConfigureAwait(false));
 
         /// <summary>
         /// Runs the test by sending an <see cref="HttpRequestMessage"/> with <i>optional</i> <paramref name="body"/> (defaults <c>Content-Type</c> to <see cref="MediaTypeNames.Text.Plain"/>).
@@ -86,13 +86,13 @@ namespace UnitTestEx.AspNetCore
         /// <param name="body">The optional body content.</param>
         /// <param name="contentType">The content type. Defaults to <see cref="MediaTypeNames.Text.Plain"/>.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequestMessage"/> modifier.</param>
-        /// <returns>An <see cref="HttpResponseMessageAssertor"/>.</returns>
+        /// <returns>An <see cref="HttpResponseMessageAssertor{TValue}"/>.</returns>
 #if NET7_0_OR_GREATER
-        public Task<HttpResponseMessageAssertor> RunAsync(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, string? body, string? contentType = MediaTypeNames.Text.Plain, Action<HttpRequestMessage>? requestModifier = null)
+        public async Task<HttpResponseMessageAssertor<TValue>> RunAsync(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, string? body, string? contentType = MediaTypeNames.Text.Plain, Action<HttpRequestMessage>? requestModifier = null)
 #else
-        public Task<HttpResponseMessageAssertor> RunAsync(HttpMethod httpMethod, string? requestUri, string? body, string? contentType = MediaTypeNames.Text.Plain, Action<HttpRequestMessage>? requestModifier = null)
+        public async Task<HttpResponseMessageAssertor<TValue>> RunAsync(HttpMethod httpMethod, string? requestUri, string? body, string? contentType = MediaTypeNames.Text.Plain, Action<HttpRequestMessage>? requestModifier = null)
 #endif
-            => SendAsync(httpMethod, requestUri, body, contentType, requestModifier);
+            => new(await SendAsync(httpMethod, requestUri, body, contentType, requestModifier));
 
         /// <summary>
         /// Runs the test by sending an <see cref="HttpRequestMessage"/> with JSON serialized <paramref name="value"/>.
@@ -101,12 +101,12 @@ namespace UnitTestEx.AspNetCore
         /// <param name="requestUri">The string that represents the request <see cref="Uri"/>.</param>
         /// <param name="value">The request body value.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequestMessage"/> modifier.</param>
-        /// <returns>An <see cref="HttpResponseMessageAssertor"/>.</returns>
+        /// <returns>An <see cref="HttpResponseMessageAssertor{TValue}"/>.</returns>
 #if NET7_0_OR_GREATER
-        public Task<HttpResponseMessageAssertor> RunAsync<T>(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, T? value, Action<HttpRequestMessage>? requestModifier = null)
+        public async Task<HttpResponseMessageAssertor<TValue>> RunAsync<T>(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, T? value, Action<HttpRequestMessage>? requestModifier = null)
 #else
-        public Task<HttpResponseMessageAssertor> RunAsync<T>(HttpMethod httpMethod, string? requestUri, T? value, Action<HttpRequestMessage>? requestModifier = null)
+        public async Task<HttpResponseMessageAssertor<TValue>> RunAsync<T>(HttpMethod httpMethod, string? requestUri, T? value, Action<HttpRequestMessage>? requestModifier = null)
 #endif
-            => SendAsync(httpMethod, requestUri, value, requestModifier);
+            => new(await SendAsync(httpMethod, requestUri, value, requestModifier).ConfigureAwait(false));
     }
 }

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
@@ -120,9 +120,17 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <param name="expectedETag">The expected ETag value.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertorBase{TSelf}"/> instance to support fluent-style method-chaining.</returns>
-        public TSelf AssertETagHeader(string expectedETag)
+        /// <remarks>An <paramref name="expectedETag"/> of <c>null</c> will confirm existence only, not the actual value.</remarks>
+        public TSelf AssertETagHeader(string? expectedETag = null)
         {
-            Implementor.AssertAreEqual(expectedETag, Response.Headers?.ETag?.Tag, $"Expected and Actual HTTP Response Header '{HeaderNames.ETag}' values are not equal.");
+            if (expectedETag is null)
+            {
+                if (Response.Headers?.ETag is null || Response.Headers?.ETag?.Tag is null)
+                    Implementor.AssertFail($"Expected an '{HeaderNames.ETag}' HTTP Response Header with a value; none was found.");
+            }
+            else
+                Implementor.AssertAreEqual(expectedETag, Response.Headers?.ETag?.Tag, $"Expected and Actual HTTP Response Header '{HeaderNames.ETag}' values are not equal.");
+
             return (TSelf)this;
         }
 

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
@@ -4,6 +4,7 @@ using Microsoft.Net.Http.Headers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Mime;
@@ -115,13 +116,24 @@ namespace UnitTestEx.Assertors
         public TSelf AssertNotModified() => Assert(HttpStatusCode.NotModified);
 
         /// <summary>
-        /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> matches the <paramref name="expectedETag"/>.
+        /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.ETag"/> matches the <paramref name="expectedETag"/>.
         /// </summary>
         /// <param name="expectedETag">The expected ETag value.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertorBase{TSelf}"/> instance to support fluent-style method-chaining.</returns>
         public TSelf AssertETagHeader(string expectedETag)
         {
             Implementor.AssertAreEqual(expectedETag, Response.Headers?.ETag?.Tag, $"Expected and Actual HTTP Response Header '{HeaderNames.ETag}' values are not equal.");
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.ETag"/> matches the <paramref name="expectedETag"/>.
+        /// </summary>
+        /// <param name="expectedETag">The expected <see cref="System.Net.Http.Headers.EntityTagHeaderValue"/> value.</param>
+        /// <returns>The <see cref="HttpResponseMessageAssertorBase{TSelf}"/> instance to support fluent-style method-chaining.</returns>
+        public TSelf AssertETagHeader(System.Net.Http.Headers.EntityTagHeaderValue expectedETag)
+        {
+            Implementor.AssertAreEqual(expectedETag, Response.Headers?.ETag, $"Expected and Actual HTTP Response Header '{HeaderNames.ETag}' values are not equal.");
             return (TSelf)this;
         }
 
@@ -242,6 +254,22 @@ namespace UnitTestEx.Assertors
             }
             else
                 Implementor.AssertAreEqual(json, Response.Content?.ReadAsStringAsync().GetAwaiter().GetResult(), "Expected and Actual JSON values are not equal.");
+
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Asserts that a response header exists with the specified <paramref name="name"/> and contains the specified <paramref name="values"/>.
+        /// </summary>
+        /// <param name="name">The header name.</param>
+        /// <param name="values">The expected header value(s).</param>
+        /// <returns>The <see cref="HttpResponseMessageAssertorBase{TSelf}"/> instance to support fluent-style method-chaining.</returns>
+        public TSelf AssertNamedHeader(string name, params string[] values)
+        {
+            if (Response.Headers.TryGetValues(name ?? throw new ArgumentNullException(nameof(name)), out var hvals))
+                Implementor.AssertAreEqual(string.Join(", ", values), string.Join(", ", hvals), $"Expected and Actual '{name}' header values are not equal.");
+            else
+                Implementor.AssertFail($"The '{name}' header was not found.");
 
             return (TSelf)this;
         }

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorT.cs
@@ -30,6 +30,12 @@ namespace UnitTestEx.Assertors
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="HttpResponseMessageAssertor"/> class.
+        /// </summary>
+        /// <param name="assertor">The untyped <see cref="HttpResponseMessageAssertor"/>.</param>
+        internal HttpResponseMessageAssertor(HttpResponseMessageAssertor assertor) : this(assertor.Owner, assertor.Response) { }
+
+        /// <summary>
         /// Gets the response content as the deserialized JSON value.
         /// </summary>
         /// <returns>The result value.</returns>
@@ -105,7 +111,7 @@ namespace UnitTestEx.Assertors
         public HttpResponseMessageAssertor<TValue> AssertValue(TValue? expectedValue, params string[] pathsToIgnore)
         {
             var cr = Owner.CreateJsonComparer().CompareValue(expectedValue, Value, pathsToIgnore);
-            if (cr is not null)
+            if (cr.HasDifferences)
                 Implementor.AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
 
             return this;

--- a/src/UnitTestEx/Assertors/ValueAssertor.cs
+++ b/src/UnitTestEx/Assertors/ValueAssertor.cs
@@ -95,10 +95,16 @@ namespace UnitTestEx.Assertors
         /// <exception cref="InvalidOperationException">Thrown where the <see cref="Result"/> <see cref="Type"/> is not <see cref="HttpResponseMessage"/>.</exception>
         public HttpResponseMessageAssertor ToHttpResponseMessageAssertor()
         {
-            if (Result != null && Result is HttpResponseMessage hrm)
-                return new HttpResponseMessageAssertor(Owner, hrm);
+            if (Result != null)
+            {
+                if (Result is HttpResponseMessage hrm)
+                    return new HttpResponseMessageAssertor(Owner, hrm);
 
-            throw new InvalidOperationException($"Result Type '{typeof(TValue).Name}' must be '{nameof(HttpResponseMessage)}' and the value must not be null.");
+                if (Result is ActionResult ar)
+                    return ActionResultAssertor.ToHttpResponseMessageAssertor(Owner, ar);
+            }
+
+            throw new InvalidOperationException($"Result Type '{typeof(TValue).Name}' must be either a '{nameof(HttpResponseMessage)}' or '{nameof(IActionResult)}', and the value must not be null.");
         }
     }
 }

--- a/src/UnitTestEx/Generic/GenericTesterCore.cs
+++ b/src/UnitTestEx/Generic/GenericTesterCore.cs
@@ -48,8 +48,14 @@ namespace UnitTestEx.Generic
         /// </summary>
         private IHost GetHost()
         {
+            if (_host is not null)
+                return _host;
+
             lock (SyncRoot)
             {
+                if (_host is not null)
+                    return _host;
+
                 var ep = new EntryPoint(Activator.CreateInstance<TEntryPoint>());
 
                 return _host ??= new HostBuilder()
@@ -86,7 +92,18 @@ namespace UnitTestEx.Generic
         }
 
         /// <inheritdoc/>
-        protected override void ResetHost() => _host = null;
+        protected override void ResetHost()
+        {
+            lock (SyncRoot)
+            {
+                if (_host is not null)
+                {
+                    _host.Dispose();
+                    _host = null;
+                    Implementor.WriteLine("The underlying UnitTestEx 'GenericTester' Host has been reset.");
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the <see cref="IServiceProvider"/> from the underlying host.

--- a/src/UnitTestEx/UnitTestEx.csproj
+++ b/src/UnitTestEx/UnitTestEx.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="YamlDotNet" Version="16.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/tests/UnitTestEx.Api/Controllers/ProductController.cs
+++ b/tests/UnitTestEx.Api/Controllers/ProductController.cs
@@ -46,5 +46,17 @@ namespace UnitTestEx.Api.Controllers
             var val = JsonConvert.DeserializeObject<dynamic>(str);
             return new OkObjectResult(val);
         }
+
+        [HttpGet("test/created")]
+        public Task<IActionResult> GetCreated()
+        {
+            return Task.FromResult((IActionResult)new CreatedResult("bananas", "abc"));
+        }
+
+        [HttpGet("test/ok")]
+        public Task<IActionResult> GetOK()
+        {
+            return Task.FromResult((IActionResult)new OkResult());
+        }
     }
 }

--- a/tests/UnitTestEx.MSTest.Test/ProductControllerTest.cs
+++ b/tests/UnitTestEx.MSTest.Test/ProductControllerTest.cs
@@ -9,7 +9,7 @@ using UnitTestEx.Api.Controllers;
 namespace UnitTestEx.MSTest.Test
 {
     [TestClass]
-    public class ProductControllerTest
+    public class ProductControllerTest : WithApiTester<Startup>
     {
         [TestMethod]
         public void Notfound_WithoutConfigurations()
@@ -20,8 +20,7 @@ namespace UnitTestEx.MSTest.Test
 
             Startup.MessageProcessingHandler.WasExecuted = false;
 
-            using var test = ApiTester.Create<Startup>();
-            test.ReplaceHttpClientFactory(mcf)
+            Test.ReplaceHttpClientFactory(mcf)
                 .Controller<ProductController>()
                 .Run(c => c.Get("xyz"))
                 .AssertNotFound();
@@ -38,8 +37,7 @@ namespace UnitTestEx.MSTest.Test
 
             Startup.MessageProcessingHandler.WasExecuted = false;
 
-            using var test = ApiTester.Create<Startup>();
-            test.ReplaceHttpClientFactory(mcf)
+            Test.ReplaceHttpClientFactory(mcf)
                 .Controller<ProductController>()
                 .Run(c => c.Get("xyz"))
                 .AssertNotFound();
@@ -54,8 +52,7 @@ namespace UnitTestEx.MSTest.Test
             mcf.CreateClient("XXX", new Uri("https://somesys"))
                 .Request(HttpMethod.Get, "products/abc").Respond.WithJson(new { id = "Abc", description = "A blue carrot" });
 
-            using var test = ApiTester.Create<Startup>();
-            test.ReplaceHttpClientFactory(mcf)
+            Test.ReplaceHttpClientFactory(mcf)
                 .Controller<ProductController>()
                 .Run(c => c.Get("abc"))
                 .AssertOK()
@@ -68,8 +65,7 @@ namespace UnitTestEx.MSTest.Test
             var mcf = MockHttpClientFactory.Create();
             mcf.CreateClient("XXX", new Uri("https://somesys")).Request(HttpMethod.Get, "test").Respond.With("test output");
 
-            using var test = ApiTester.Create<Startup>();
-            var hc = test.ReplaceHttpClientFactory(mcf)
+            var hc = Test.ReplaceHttpClientFactory(mcf)
                 .Services.GetService<IHttpClientFactory>().CreateClient("XXX");
 
             var r = hc.GetAsync("test").Result;
@@ -85,8 +81,7 @@ namespace UnitTestEx.MSTest.Test
 
             Startup.MessageProcessingHandler.WasExecuted = false;
 
-            using var test = ApiTester.Create<Startup>();
-            var hc = test.ReplaceHttpClientFactory(mcf)
+            var hc = Test.ReplaceHttpClientFactory(mcf)
                 .Services.GetService<IHttpClientFactory>().CreateClient("XXX");
 
             var ex = Assert.ThrowsException<AggregateException>(() => hc.GetAsync("test").Result);
@@ -104,8 +99,7 @@ namespace UnitTestEx.MSTest.Test
 
             Startup.MessageProcessingHandler.WasExecuted = false;
 
-            using var test = ApiTester.Create<Startup>();
-            var hc = test.ReplaceHttpClientFactory(mcf)
+            var hc = Test.ReplaceHttpClientFactory(mcf)
                 .Services.GetService<IHttpClientFactory>().CreateClient("XXX");
 
             var ex = Assert.ThrowsException<AggregateException>(() => hc.GetAsync("test").Result);


### PR DESCRIPTION
- *Enhancement:* All `CreateHttpRequest` and related methods moved to `TesterBase` to ensure availability for all derived testers.
- *Enhancement:* Added `ToHttpResponseMessageAssertor` to `ActionResultAssertor` and `ValueAssertor` that converts an `IActionResult` to an `HttpResponseMessage` and returns an `HttpResponseMessageAssertor` for further assertions. The underlying `Host` must be configured (DI) correctly for this to function; otherwise, an exception will be thrown.
- *Enhancement:* Added `WithApiTester` base class per test framework to provide a shared `ApiTester` instance per test class; versus instantiating per test method. Be aware that using may result in cross-test contamination.