### PR TITLE
v5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.4.1
+- *Fixed:* The `ToHttpResponseMessageAssertor` supports a new `HttpRequest` parameter to enable access to the originating `HttpContext` such that its `HttpResponse` is used; versus, creating new internally.
+
 ## v5.4.0
 - *Enhancement:* All `CreateHttpRequest` and related methods moved to `TesterBase` to ensure availability for all derived testers.
 - *Enhancement:* Added `ToHttpResponseMessageAssertor` to `ActionResultAssertor` and `ValueAssertor` that converts an `IActionResult` to an `HttpResponseMessage` and returns an `HttpResponseMessageAssertor` for further assertions. The underlying `Host` must be configured (DI) correctly for this to function; otherwise, an exception will be thrown.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.4.0</Version>
+		<Version>5.4.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx/Abstractions/TesterBase.cs
+++ b/src/UnitTestEx/Abstractions/TesterBase.cs
@@ -353,7 +353,10 @@ namespace UnitTestEx.Abstractions
             if (httpMethod == HttpMethod.Get && body != null)
                 LoggerProvider.CreateLogger("FunctionTesterBase").LogWarning("A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request (see https://www.rfc-editor.org/rfc/rfc7231).");
 
-            var context = new DefaultHttpContext();
+            var context = new DefaultHttpContext
+            {
+                RequestServices = Services
+            };
 
             var uri = requestUri is null ? new Uri("http://unittestex") : new Uri(requestUri, UriKind.RelativeOrAbsolute);
             if (!uri.IsAbsoluteUri)

--- a/src/UnitTestEx/Assertors/ActionResultAssertor.cs
+++ b/src/UnitTestEx/Assertors/ActionResultAssertor.cs
@@ -482,20 +482,22 @@ namespace UnitTestEx.Assertors
         /// <summary>
         /// Converts the <see cref="IActionResult"/> to an <see cref="HttpResponseMessageAssertor"/>.
         /// </summary>
+        /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/> with <see cref="HttpContext"/>; otherwise, will default.</param>
         /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
-        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor() => ToHttpResponseMessageAssertor(Owner, Result);
+        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor(HttpRequest? httpRequest = null) => ToHttpResponseMessageAssertor(Owner, Result, httpRequest);
 
         /// <summary>
         /// Converts the <see cref="ValueAssertor{TValue}"/> to an <see cref="HttpResponseMessageAssertor"/>.
         /// </summary>
         /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
         /// <param name="result">The <see cref="IActionResult"/> to convert.</param>
+        /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/>; otherwise, will default.</param>
         /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
-        internal static HttpResponseMessageAssertor ToHttpResponseMessageAssertor(TesterBase owner, IActionResult result)
+        internal static HttpResponseMessageAssertor ToHttpResponseMessageAssertor(TesterBase owner, IActionResult result, HttpRequest? httpRequest)
         {
             var sw = Stopwatch.StartNew();
             using var ms = new MemoryStream();
-            var context = new DefaultHttpContext { RequestServices = owner.Services };
+            var context = httpRequest?.HttpContext ?? new DefaultHttpContext { RequestServices = owner.Services };
             context.Response.Body = ms;
 
             result.ExecuteResultAsync(new ActionContext(context, new Microsoft.AspNetCore.Routing.RouteData(), new ActionDescriptor())).GetAwaiter().GetResult();

--- a/src/UnitTestEx/Assertors/ValueAssertor.cs
+++ b/src/UnitTestEx/Assertors/ValueAssertor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -92,8 +93,9 @@ namespace UnitTestEx.Assertors
         /// Converts the <see cref="ValueAssertor{TValue}"/> to an <see cref="HttpResponseMessageAssertor"/>.
         /// </summary>
         /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
+        /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/> with <see cref="HttpContext"/>; otherwise, will default.</param>
         /// <exception cref="InvalidOperationException">Thrown where the <see cref="Result"/> <see cref="Type"/> is not <see cref="HttpResponseMessage"/>.</exception>
-        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor()
+        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor(HttpRequest? httpRequest = null)
         {
             if (Result != null)
             {
@@ -101,7 +103,7 @@ namespace UnitTestEx.Assertors
                     return new HttpResponseMessageAssertor(Owner, hrm);
 
                 if (Result is ActionResult ar)
-                    return ActionResultAssertor.ToHttpResponseMessageAssertor(Owner, ar);
+                    return ActionResultAssertor.ToHttpResponseMessageAssertor(Owner, ar, httpRequest);
             }
 
             throw new InvalidOperationException($"Result Type '{typeof(TValue).Name}' must be either a '{nameof(HttpResponseMessage)}' or '{nameof(IActionResult)}', and the value must not be null.");

--- a/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -305,6 +306,20 @@ namespace UnitTestEx.NUnit.Test
             test.Http<Person>()
                 .Run(HttpMethod.Post, "Person/1", new Person { FirstName = "Bob", LastName = "Smith" })
                 .AssertValue(new Person { Id = 1, FirstName = "Bob", LastName = "Smith" });
+        }
+
+        [Test]
+        public void Type_IActionResult()
+        {
+            using var test = ApiTester.Create<Startup>();
+            var hr = test.CreateHttpRequest(HttpMethod.Get, "Person/1");
+            hr.HttpContext.Response.Headers.Add("X-Test", "Test");
+
+            var iar = new OkResult();
+
+            new Assertors.ValueAssertor<IActionResult>(test, iar, null)
+                .ToHttpResponseMessageAssertor(hr)
+                .AssertNamedHeader("X-Test", "Test");
         }
     }
 }


### PR DESCRIPTION
- *Fixed:* The `ToHttpResponseMessageAssertor` supports a new `HttpRequest` parameter to enable access to the originating `HttpContext` such that its `HttpResponse` is used; versus, creating new internally.