### PR TITLE
v5.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.4.2
+- *Fixed:* The `HttpResponseMessageAssertorBase.AssertErrors` has been extended to check for both `IDictionary<string, string[]>` (previous) and `HttpValidationProblemDetails` (new) HTTP response JSON content.
+
 ## v5.4.1
 - *Fixed:* The `ToHttpResponseMessageAssertor` supports a new `HttpRequest` parameter to enable access to the originating `HttpContext` such that its `HttpResponse` is used; versus, creating new internally.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Represents the **NuGet** versions.
 
 ## v5.4.2
 - *Fixed:* The `HttpResponseMessageAssertorBase.AssertErrors` has been extended to check for both `IDictionary<string, string[]>` (previous) and `HttpValidationProblemDetails` (new) HTTP response JSON content.
+- *Fixed:* The `HttpResponseMessageAssertorBase.AssertJson` corrected to not validate the content type as this should be handled by the `AssertContentType` method. The `AssertJson` method now only checks the content against the expected JSON value.
 
 ## v5.4.1
 - *Fixed:* The `ToHttpResponseMessageAssertor` supports a new `HttpRequest` parameter to enable access to the originating `HttpContext` such that its `HttpResponse` is used; versus, creating new internally.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.4.1</Version>
+		<Version>5.4.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx/Assertors/Assertor.cs
+++ b/src/UnitTestEx/Assertors/Assertor.cs
@@ -17,7 +17,7 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <param name="errors">The errors.</param>
         /// <returns>The <see cref="ApiError"/> array.</returns>
-        public static ApiError[] ConvertToApiErrors(Dictionary<string, string[]>? errors)
+        public static ApiError[] ConvertToApiErrors(IDictionary<string, string[]>? errors)
         {
             List<ApiError>? actual = [];
 

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBase.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBase.cs
@@ -42,11 +42,13 @@ namespace UnitTestEx.Assertors
         /// Gets the response content as the deserialized JSON value.
         /// </summary>
         /// <typeparam name="T">The content <see cref="Type"/>.</typeparam>
+        /// <param name="expectedContentType">The expected content type; where <c>null</c> then the content type will not be validated.</param>
         /// <returns>The result value.</returns>
-        /// <remarks>The content type must be <see cref="MediaTypeNames.Application.Json"/>.</remarks>
-        public T? GetValue<T>()
+        public T? GetValue<T>(string? expectedContentType = MediaTypeNames.Application.Json)
         {
-            Implementor.AssertAreEqual(MediaTypeNames.Application.Json, Response.Content?.Headers?.ContentType?.MediaType);
+            if (expectedContentType is not null)
+                Implementor.AssertAreEqual(expectedContentType, Response.Content?.Headers?.ContentType?.MediaType);
+
             if (Response.Content == null)
                 return default!;
 

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
@@ -273,14 +273,9 @@ namespace UnitTestEx.Assertors
                 return (TSelf)this;
             }
 
-            if (Response.Content?.Headers?.ContentType?.MediaType == MediaTypeNames.Application.Json)
-            {
-                var jc = Owner.CreateJsonComparer().Compare(json, Response.Content.ReadAsStringAsync().GetAwaiter().GetResult(), pathsToIgnore);
-                if (jc.HasDifferences)
-                    Implementor.AssertFail($"Expected and Actual JSON values are not equal:{Environment.NewLine}{jc}");
-            }
-            else
-                Implementor.AssertAreEqual(json, Response.Content?.ReadAsStringAsync().GetAwaiter().GetResult(), "Expected and Actual JSON values are not equal.");
+            var jc = Owner.CreateJsonComparer().Compare(json, Response.Content.ReadAsStringAsync().GetAwaiter().GetResult(), pathsToIgnore);
+            if (jc.HasDifferences)
+                Implementor.AssertFail($"Expected and Actual JSON values are not equal:{Environment.NewLine}{jc}");
 
             return (TSelf)this;
         }

--- a/tests/UnitTestEx.Api/Controllers/ProductController.cs
+++ b/tests/UnitTestEx.Api/Controllers/ProductController.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -57,6 +59,12 @@ namespace UnitTestEx.Api.Controllers
         public Task<IActionResult> GetOK()
         {
             return Task.FromResult((IActionResult)new OkResult());
+        }
+
+        [HttpGet("test/problem")]
+        public Task<IActionResult> GetProblem()
+        {
+            return Task.FromResult((IActionResult)new JsonResult(new HttpValidationProblemDetails(new Dictionary<string, string[]> { { "id", ["Not specified."] } } )));
         }
     }
 }

--- a/tests/UnitTestEx.Api/UnitTestEx.Api.csproj
+++ b/tests/UnitTestEx.Api/UnitTestEx.Api.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/UnitTestEx.NUnit.Test/ProductControllerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/ProductControllerTest.cs
@@ -130,5 +130,14 @@ namespace UnitTestEx.NUnit.Test
                 .AssertOK()
                 .AssertValue(new { id = "Def", description = "Default" });
         }
+
+        [Test]
+        public void ValidationProblemDetails()
+        {
+            using var test = ApiTester.Create<Startup>();
+            test.Http()
+                .Run(HttpMethod.Get, "product/test/problem")
+                .AssertErrors(new ApiError("id", "Not specified."));
+        }
     }
 }


### PR DESCRIPTION
- *Fixed:* The `HttpResponseMessageAssertorBase.AssertErrors` has been extended to check for both `IDictionary<string, string[]>` (previous) and `HttpValidationProblemDetails` (new) HTTP response JSON content.
- *Fixed:* The `HttpResponseMessageAssertorBase.AssertJson` corrected to not validate the content type as this should be handled by the `AssertContentType` method. The `AssertJson` method now only checks the content against the expected JSON value.