### PR TITLE
v5.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v5.4.3
+- *Fixed:* The `ValueAssertor.Result` is being obsoleted and replaced with `ValueAssertor.Value` to be more explicit. The `Result` property will be removed in a future version.
+- *Fixed:* The `ValueAssertor` JSON-based assertions updated to serialize the `Value` and compare; versus, serializing the JSON and then comparing.
+- *Fixed:* The `ObjectComparer.JsonAssert` is being obsoleted and replaced with `ObjectComparer.AssertJson` to be more consistent. The `JsonAssert` method will be removed in a future version.
+
 ## v5.4.2
 - *Fixed:* The `HttpResponseMessageAssertorBase.AssertErrors` has been extended to check for both `IDictionary<string, string[]>` (previous) and `HttpValidationProblemDetails` (new) HTTP response JSON content.
 - *Fixed:* The `HttpResponseMessageAssertorBase.AssertJson` corrected to not validate the content type as this should be handled by the `AssertContentType` method. The `AssertJson` method now only checks the content against the expected JSON value.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.4.2</Version>
+		<Version>5.4.3</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx.Xunit/ApiTestFixture.cs
+++ b/src/UnitTestEx.Xunit/ApiTestFixture.cs
@@ -10,20 +10,39 @@ namespace UnitTestEx
     /// Provides a shared <see cref="Test"/> <see cref="ApiTester{TEntryPoint}"/> to enable usage of the same underlying <see cref="ApiTesterBase{TEntryPoint, TSelf}.GetTestServer"/> instance across multiple tests.
     /// </summary>
     /// <remarks>Be aware that using may result in cross-test contamination.</remarks>
-    public sealed class ApiTestFixture<TEntryPoint> : IDisposable where TEntryPoint : class
+    public class ApiTestFixture<TEntryPoint> : IDisposable where TEntryPoint : class
     {
         private ApiTester<TEntryPoint>? _apiTester = ApiTester.Create<TEntryPoint>(() => new XunitLocalTestImplementor());
+        private bool _disposed;
 
         /// <summary>
         /// Gets the shared <see cref="ApiTester{TEntryPoint}"/> for testing.
         /// </summary>
         public ApiTester<TEntryPoint> Test => _apiTester ?? throw new ObjectDisposedException(nameof(Test));
 
+        /// <summary>
+        /// Releases the unmanaged resources and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _apiTester?.Dispose();
+                    _apiTester = null;
+                }
+
+                _disposed = true;
+            }
+        }
+
         /// <inheritdoc/>
         public void Dispose()
         {
-            _apiTester?.Dispose();
-            _apiTester = null;
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/UnitTestEx/Assertors/ValueAssertor.cs
+++ b/src/UnitTestEx/Assertors/ValueAssertor.cs
@@ -15,76 +15,85 @@ namespace UnitTestEx.Assertors
     /// </summary>
     /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
-    /// <param name="result">The result value.</param>
+    /// <param name="value">The result value.</param>
     /// <param name="exception">The <see cref="Exception"/> (if any).</param>
-    public class ValueAssertor<TValue>(TesterBase owner, TValue result, Exception? exception) : AssertorBase<ValueAssertor<TValue>>(owner, exception)
+    public class ValueAssertor<TValue>(TesterBase owner, TValue value, Exception? exception) : AssertorBase<ValueAssertor<TValue>>(owner, exception)
     {
+        /// <summary>
+        /// Gets the resulting value.
+        /// </summary>
+        public TValue Value { get; } = value;
+
         /// <summary>
         /// Gets the result.
         /// </summary>
-        public TValue Result { get; } = result;
+        [Obsolete("The Result is being renamed to Value as this name is more obvious.")]
+        public TValue Result { get; } = value;
 
         /// <summary>
-        /// Asserts that the <see cref="Result"/> matches the <paramref name="expectedValue"/>.
+        /// Asserts that the <see cref="Value"/> matches the <paramref name="expectedValue"/>.
         /// </summary>
         /// <param name="expectedValue">The expected value.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
-        public ValueAssertor<TValue> AssertValue(TValue expectedValue, params string[] pathsToIgnore)
+        public ValueAssertor<TValue> AssertValue(TValue? expectedValue, params string[] pathsToIgnore)
         {
             AssertSuccess();
-            if (expectedValue is IComparable)
-                Implementor.AssertAreEqual(expectedValue, Result);
-            else
-            {
-                var cr = Owner.CreateJsonComparer().CompareValue(expectedValue, Result, pathsToIgnore);
-                if (cr.HasDifferences)
-                    Implementor.AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
-            }
+            var cr = Owner.CreateJsonComparer().CompareValue(expectedValue, Value, pathsToIgnore);
+            if (cr.HasDifferences)
+                Implementor.AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
 
             return this;
         }
 
         /// <summary>
-        ///  Asserts that the <see cref="Result"/> matches the <paramref name="json"/> serialized value.
+        ///  Asserts that the <see cref="Value"/> matches the <paramref name="json"/> serialized value.
         /// </summary>
         /// <param name="json">The JSON <see cref="string"/>.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
 #if NET7_0_OR_GREATER
-        public ValueAssertor<TValue> AssertJson([StringSyntax(StringSyntaxAttribute.Json)] string json, params string[] pathsToIgnore) => AssertValue(JsonSerializer.Deserialize<TValue>(json)!, pathsToIgnore);
+        public ValueAssertor<TValue> AssertJson([StringSyntax(StringSyntaxAttribute.Json)] string json, params string[] pathsToIgnore)
 #else
-        public ValueAssertor<TValue> AssertJson(string json, params string[] pathsToIgnore) => AssertValue(JsonSerializer.Deserialize<TValue>(json)!, pathsToIgnore);
+        public ValueAssertor<TValue> AssertJson(string json, params string[] pathsToIgnore)
 #endif
+        {
+            AssertSuccess();
+            var cr = Owner.CreateJsonComparer().CompareValue(json, JsonSerializer.Serialize(Value), pathsToIgnore);
+            if (cr.HasDifferences)
+                Implementor.AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
+
+            return this;
+        }
 
         /// <summary>
-        /// Asserts that the <see cref="Result"/> matches the JSON serialized value from the named embedded resource.
+        /// Asserts that the <see cref="Value"/> matches the JSON serialized value from the named embedded resource.
         /// </summary>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
         public ValueAssertor<TValue> AssertJsonFromResource(string resourceName, params string[] pathsToIgnore)
-            => AssertValue(Resource.GetJsonValue<TValue>(resourceName, Assembly.GetCallingAssembly(), JsonSerializer), pathsToIgnore);
+            => AssertJson(Resource.GetJson(resourceName, Assembly.GetCallingAssembly()), pathsToIgnore);
 
         /// <summary>
-        /// Asserts that the <see cref="Result"/> matches the JSON serialized value from the named embedded resource.
+        /// Asserts that the <see cref="Value"/> matches the JSON serialized value from the named embedded resource.
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
         public ValueAssertor<TValue> AssertJsonFromResource<TAssembly>(string resourceName, params string[] pathsToIgnore)
-            => AssertValue(Resource.GetJsonValue<TValue>(resourceName, typeof(TAssembly).Assembly, JsonSerializer), pathsToIgnore);
+            => AssertJson(Resource.GetJson(resourceName, typeof(TAssembly).Assembly), pathsToIgnore);
 
         /// <summary>
         /// Converts the <see cref="ValueAssertor{TValue}"/> to an <see cref="ActionResultAssertor"/>.
         /// </summary>
         /// <returns>The corresponding <see cref="ActionResultAssertor"/>.</returns>
-        /// <exception cref="InvalidOperationException">Thrown where the <see cref="Result"/> <see cref="Type"/> is not assignable from <see cref="IActionResult"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown where the <see cref="Value"/> <see cref="Type"/> is not assignable from <see cref="IActionResult"/>.</exception>
         public ActionResultAssertor ToActionResultAssertor()
         {
             if (typeof(IActionResult).IsAssignableFrom(typeof(TValue)))
-                return new ActionResultAssertor(Owner, (IActionResult)Result!, Exception);
+                return new ActionResultAssertor(Owner, (IActionResult)Value!, Exception);
 
             throw new InvalidOperationException($"Result Type '{typeof(TValue).Name}' must be assignable from '{nameof(IActionResult)}'");
         }
@@ -94,15 +103,15 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
         /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/> with <see cref="HttpContext"/>; otherwise, will default.</param>
-        /// <exception cref="InvalidOperationException">Thrown where the <see cref="Result"/> <see cref="Type"/> is not <see cref="HttpResponseMessage"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown where the <see cref="Value"/> <see cref="Type"/> is not <see cref="HttpResponseMessage"/>.</exception>
         public HttpResponseMessageAssertor ToHttpResponseMessageAssertor(HttpRequest? httpRequest = null)
         {
-            if (Result != null)
+            if (Value != null)
             {
-                if (Result is HttpResponseMessage hrm)
+                if (Value is HttpResponseMessage hrm)
                     return new HttpResponseMessageAssertor(Owner, hrm);
 
-                if (Result is ActionResult ar)
+                if (Value is ActionResult ar)
                     return ActionResultAssertor.ToHttpResponseMessageAssertor(Owner, ar, httpRequest);
             }
 

--- a/src/UnitTestEx/Logging/LoggerBase.cs
+++ b/src/UnitTestEx/Logging/LoggerBase.cs
@@ -25,7 +25,7 @@ namespace UnitTestEx.Logging
         public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
 
         /// <inheritdoc />
-#if NET7_0_OR_GREATER
+#if NET6_0_OR_GREATER
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => _scopeProvider.Push(state);
 #else
         public IDisposable BeginScope<TState>(TState state) => _scopeProvider.Push(state);

--- a/src/UnitTestEx/ObjectComparer.cs
+++ b/src/UnitTestEx/ObjectComparer.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using UnitTestEx.Abstractions;
 using UnitTestEx.Json;
 
@@ -59,10 +60,38 @@ namespace UnitTestEx
         /// <param name="expected">The expected JSON.</param>
         /// <param name="actual">The actual JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
+        [Obsolete("The JsonAssert is being renamed to AssertJson as this name is standard with UnitTestEx.")]
 #if NET7_0_OR_GREATER
-        public static void JsonAssert([StringSyntax(StringSyntaxAttribute.Json)] string? expected, [StringSyntax(StringSyntaxAttribute.Json)] string? actual, params string[] pathsToIgnore) => JsonAssert(null, expected, actual, pathsToIgnore);
+        public static void JsonAssert([StringSyntax(StringSyntaxAttribute.Json)] string? expected, [StringSyntax(StringSyntaxAttribute.Json)] string? actual, params string[] pathsToIgnore) => AssertJson(null, expected, actual, pathsToIgnore);
 #else
-        public static void JsonAssert(string? expected, string? actual, params string[] pathsToIgnore) => JsonAssert(null, expected, actual, pathsToIgnore);
+        public static void JsonAssert(string? expected, string? actual, params string[] pathsToIgnore) => AssertJson(null, expected, actual, pathsToIgnore);
+#endif
+
+        /// <summary>
+        /// Compares two JSON strings to each other.
+        /// </summary>
+        /// <param name="options">The <see cref="JsonElementComparerOptions"/>.</param>
+        /// <param name="expected">The expected JSON.</param>
+        /// <param name="actual">The actual JSON.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
+        [Obsolete("The JsonAssert is being renamed to AssertJson as this name is standard with UnitTestEx.")]
+#if NET7_0_OR_GREATER
+        public static void JsonAssert(JsonElementComparerOptions? options, [StringSyntax(StringSyntaxAttribute.Json)] string? expected, [StringSyntax(StringSyntaxAttribute.Json)] string? actual, params string[] pathsToIgnore)
+#else
+        public static void JsonAssert(JsonElementComparerOptions? options, string? expected, string? actual, params string[] pathsToIgnore)
+#endif
+            => AssertJson(options, expected, actual, pathsToIgnore);
+
+        /// <summary>
+        /// Compares two JSON strings to each other.
+        /// </summary>
+        /// <param name="expected">The expected JSON.</param>
+        /// <param name="actual">The actual JSON.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
+#if NET7_0_OR_GREATER
+        public static void AssertJson([StringSyntax(StringSyntaxAttribute.Json)] string? expected, [StringSyntax(StringSyntaxAttribute.Json)] string? actual, params string[] pathsToIgnore) => AssertJson(null, expected, actual, pathsToIgnore);
+#else
+        public static void AssertJson(string? expected, string? actual, params string[] pathsToIgnore) => AssertJson(null, expected, actual, pathsToIgnore);
 #endif
 
         /// <summary>
@@ -73,9 +102,9 @@ namespace UnitTestEx
         /// <param name="actual">The actual JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
 #if NET7_0_OR_GREATER
-        public static void JsonAssert(JsonElementComparerOptions? options, [StringSyntax(StringSyntaxAttribute.Json)] string? expected, [StringSyntax(StringSyntaxAttribute.Json)] string? actual, params string[] pathsToIgnore)
+        public static void AssertJson(JsonElementComparerOptions? options, [StringSyntax(StringSyntaxAttribute.Json)] string? expected, [StringSyntax(StringSyntaxAttribute.Json)] string? actual, params string[] pathsToIgnore)
 #else
-        public static void JsonAssert(JsonElementComparerOptions? options, string? expected, string? actual, params string[] pathsToIgnore)
+        public static void AssertJson(JsonElementComparerOptions? options, string? expected, string? actual, params string[] pathsToIgnore)
 #endif
         {
             if (expected is null && actual is null)
@@ -100,5 +129,24 @@ namespace UnitTestEx
             if (cr.HasDifferences)
                 TestFrameworkImplementor.Create().AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
         }
+
+        /// <summary>
+        /// Compares two JSON strings to each other where the expected JSON is from an embedded resource.
+        /// </summary>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected JSON.</param>
+        /// <param name="actual">The actual JSON.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
+        public static void AssertJsonFromResource(string resourceName, string? actual, params string[] pathsToIgnore)
+            => AssertJson(Resource.GetJson(resourceName, Assembly.GetCallingAssembly()), actual, pathsToIgnore);
+
+        /// <summary>
+        /// Compares two JSON strings to each other where the expected JSON is from an embedded resource.
+        /// </summary>
+        /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected JSON.</param>
+        /// <param name="actual">The actual JSON.</param>
+        /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
+        public static void AssertJsonFromResource<TAssembly>(string resourceName, string? actual, params string[] pathsToIgnore)
+            => AssertJson(Resource.GetJson(resourceName, typeof(TAssembly).Assembly), actual, pathsToIgnore);
     }
 }

--- a/src/UnitTestEx/TestSetUp.cs
+++ b/src/UnitTestEx/TestSetUp.cs
@@ -177,7 +177,7 @@ namespace UnitTestEx
         public Func<HttpRequest, string?, CancellationToken, Task>? OnBeforeHttpRequestSendAsync { get; set; }
 
         /// <summary>
-        /// Gets or sets the minimum <see cref="LogLevel"/> when configuring the underlying host (see <see cref="ILoggingBuilder"/>).
+        /// Gets or sets the minimum <see cref="LogLevel"/> when configuring the underlying host.
         /// </summary>
         public LogLevel MinimumLogLevel { get; set; } = LogLevel.Debug;
 

--- a/tests/UnitTestEx.NUnit.Test/MockHttpClientTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/MockHttpClientTest.cs
@@ -438,14 +438,14 @@ namespace UnitTestEx.NUnit.Test
             Assert.Multiple(async () =>
             {
                 Assert.That(res.StatusCode, Is.EqualTo(HttpStatusCode.Accepted));
-                ObjectComparer.JsonAssert("{\"product\":\"xyz\",\"quantity\":1}", await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+                ObjectComparer.AssertJson("{\"product\":\"xyz\",\"quantity\":1}", await res.Content.ReadAsStringAsync().ConfigureAwait(false));
             });
 
             res = await hc.GetAsync("people/123");
             Assert.Multiple(async () =>
             {
                 Assert.That(res.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-                ObjectComparer.JsonAssert("{\"first\":\"Bob\",\"last\":\"Jane\"}", await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+                ObjectComparer.AssertJson("{\"first\":\"Bob\",\"last\":\"Jane\"}", await res.Content.ReadAsStringAsync().ConfigureAwait(false));
                 Assert.That(res.Headers.GetValues("x-blah").Single(), Is.EqualTo("abc"));
                 Assert.That(res.Headers.Age, Is.EqualTo(TimeSpan.FromSeconds(55)));
             });
@@ -464,14 +464,14 @@ namespace UnitTestEx.NUnit.Test
             Assert.Multiple(async () =>
             {
                 Assert.That(res.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-                ObjectComparer.JsonAssert("{\"first\":\"Bob\",\"last\":\"Jane\"}", await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+                ObjectComparer.AssertJson("{\"first\":\"Bob\",\"last\":\"Jane\"}", await res.Content.ReadAsStringAsync().ConfigureAwait(false));
             });
 
             res = await hc.GetAsync("people/123");
             Assert.Multiple(async () =>
             {
                 Assert.That(res.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-                ObjectComparer.JsonAssert("{\"first\":\"Sarah\",\"last\":\"Johns\"}", await res.Content.ReadAsStringAsync().ConfigureAwait(false));
+                ObjectComparer.AssertJson("{\"first\":\"Sarah\",\"last\":\"Johns\"}", await res.Content.ReadAsStringAsync().ConfigureAwait(false));
             });
 
             mcf.VerifyAll();

--- a/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
@@ -20,6 +20,15 @@ namespace UnitTestEx.NUnit.Test.Other
         }
 
         [Test]
+        public void Run_Success_AssertJSON()
+        {
+            using var test = GenericTester.Create();
+            test.Run(() => 1)
+                .AssertSuccess()
+                .AssertJson("1");
+        }
+
+        [Test]
         public void Run_Exception()
         {
             using var test = GenericTester.Create();


### PR DESCRIPTION
- *Fixed:* The `ValueAssertor.Result` is being obsoleted and replaced with `ValueAssertor.Value` to be more explicit. The `Result` property will be removed in a future version.
- *Fixed:* The `ValueAssertor` JSON-based assertions updated to serialize the `Value` and compare; versus, serializing the JSON and then comparing.
- *Fixed:* The `ObjectComparer.JsonAssert` is being obsoleted and replaced with `ObjectComparer.AssertJson` to be more consistent. The `JsonAssert` method will be removed in a future version.