### PR TITLE
v5.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.4.6
+- *Fixed:* Added `TestFrameworkImplementor.SetLocalCreateFactory` to Xunit `ApiTestFixture` constructor to ensure set correctly for the `OnConfiguration` method override.
+
 ## v5.4.5
 - *Fixed:* Added `TesterBase.JsonMediaTypeNames` which provides a list of valid JSON media types to be used to determine JSON-related payloads in tests.
 - *Fixed:* Added Xunit `ApiTestFixture.OnConfiguration` to enable configuration to be perform prior to test execution.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.4.5</Version>
+		<Version>5.4.6</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx.Xunit/ApiTestFixture.cs
+++ b/src/UnitTestEx.Xunit/ApiTestFixture.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
 using System;
+using UnitTestEx.Abstractions;
 using UnitTestEx.AspNetCore;
 using UnitTestEx.Xunit.Internal;
 
@@ -18,7 +19,11 @@ namespace UnitTestEx
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiTestFixture{TEntryPoint}"/> class.
         /// </summary>
-        public ApiTestFixture() => OnConfiguration();
+        public ApiTestFixture()
+        {
+            TestFrameworkImplementor.SetLocalCreateFactory(() => new XunitLocalTestImplementor());
+            OnConfiguration();
+        }
 
         /// <summary>
         /// Provides an opportunity to perform initial <see cref="Test"/> configuration before use.

--- a/tests/UnitTestEx.Xunit.Test/ProductApiTestFixture.cs
+++ b/tests/UnitTestEx.Xunit.Test/ProductApiTestFixture.cs
@@ -8,11 +8,16 @@ namespace UnitTestEx.Xunit.Test
 
         protected override void OnConfiguration()
         {
+            Test.ReplaceSingleton<TestSomeSome>();
+            MockHttpClientFactory.Create();
+
             _counter++;
             if (_counter > 1)
             {
                 throw new InvalidOperationException("ProductApiTestFixture should only be instantiated once per test run.");
             }
         }
+
+        public class TestSomeSome { }
     }
 }


### PR DESCRIPTION
- *Fixed:* Added `TestFrameworkImplementor.SetLocalCreateFactory` to Xunit `ApiTestFixture` constructor to ensure set correctly for the `OnConfiguration` method override.