### PR TITLE
v5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.5.0
+- *Enhancement:* The `GenericTester` where using `.NET8.0` and above will leverage the new `IHostApplicationBuilder` versus existing `IHostBuilder` (see Microsoft [documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/generic-host) and [recommendation](https://github.com/dotnet/runtime/discussions/81090#discussioncomment-4784551)). Additionally, if a `TEntryPoint` is specified with a method signature of `public void ConfigureApplication(IHostApplicationBuilder builder)` then this will be automatically invoked during host instantiation. This is a non-breaking change as largely internal.
+
 ## v5.4.6
 - *Fixed:* Added `TestFrameworkImplementor.SetLocalCreateFactory` to Xunit `ApiTestFixture` constructor to ensure set correctly for the `OnConfiguration` method override.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.4.6</Version>
+		<Version>5.5.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ test.Run<Gin, int>(gin => gin.Pour())
     .AssertValue(1);
 ```
 
+Additionally, where the `TEntryPoint` is specified and implements `ConfigureApplication` (`.NET8.0` or above) this will be invoked automatically to perform any additional configuration. 
+
+``` csharp
+using var test = GenericTester.Create<Startup>();
+test.Run<Gin, int>(gin => gin.Pour())
+    .AssertSuccess()
+    .AssertValue(1);
+
+public class Startup
+{
+    public void ConfigureApplication(IHostApplicationBuilder builder) => builder.Services.AddSingleton<Gin>();
+}
+```
+
 <br/>
 
 ## DI Mocking

--- a/src/UnitTestEx/Hosting/EntryPoint.cs
+++ b/src/UnitTestEx/Hosting/EntryPoint.cs
@@ -18,6 +18,9 @@ namespace UnitTestEx.Hosting
         private readonly MethodInfo? _mi1;
         private readonly MethodInfo? _mi2;
         private readonly MethodInfo? _mi3;
+#if NET8_0_OR_GREATER
+        private readonly MethodInfo? _mi4;
+#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntryPoint"/> class.
@@ -29,7 +32,33 @@ namespace UnitTestEx.Hosting
             _mi1 = instance.GetType().GetMethod(nameof(ConfigureAppConfiguration), BindingFlags.Instance | BindingFlags.Public, [typeof(HostBuilderContext), typeof(IConfigurationBuilder)]);
             _mi2 = instance.GetType().GetMethod(nameof(ConfigureHostConfiguration), BindingFlags.Instance | BindingFlags.Public, [typeof(IConfigurationBuilder)]);
             _mi3 = instance.GetType().GetMethod(nameof(ConfigureServices), BindingFlags.Instance | BindingFlags.Public, [typeof(IServiceCollection)]);
+            _mi3 = instance.GetType().GetMethod(nameof(ConfigureServices), BindingFlags.Instance | BindingFlags.Public, [typeof(IServiceCollection)]);
+#if NET8_0_OR_GREATER
+            _mi4 = instance.GetType().GetMethod(nameof(ConfigureApplication), BindingFlags.Instance | BindingFlags.Public, [typeof(IHostApplicationBuilder)]);
+#endif
         }
+
+        /// <summary>
+        /// Indicates whether the <see cref="ConfigureAppConfiguration"/> has been defined on the entry point instance.
+        /// </summary>
+        public bool HasConfigureAppConfiguration => _mi1 is not null;
+
+        /// <summary>
+        /// Indicates whether the <see cref="ConfigureHostConfiguration"/> has been defined on the entry point instance.
+        /// </summary>
+        public bool HasConfigureHostConfiguration => _mi2 is not null;
+
+        /// <summary>
+        /// Indicates whether the <see cref="ConfigureServices"/> has been defined on the entry point instance.
+        /// </summary>
+        public bool HasConfigureServices => _mi3 is not null;
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Indicates whether the <see cref="ConfigureApplication"/> has been defined on the entry point instance.
+        /// </summary>
+        public bool HasConfigureApplication => _mi4 is not null;
+#endif
 
         /// <summary>
         /// Sets up the configuration for the remainder of the build process and application.
@@ -37,20 +66,28 @@ namespace UnitTestEx.Hosting
         /// <param name="context"></param>
         /// <param name="config"></param>
         /// <remarks>This is intended to be invoked by the <see cref="IHostBuilder.ConfigureAppConfiguration(System.Action{HostBuilderContext, IConfigurationBuilder})"/>.</remarks>
-        public void ConfigureAppConfiguration(HostBuilderContext context, IConfigurationBuilder config) => _mi1?.Invoke(_instance, new object[] { context, config });
+        public void ConfigureAppConfiguration(HostBuilderContext context, IConfigurationBuilder config) => _mi1?.Invoke(_instance, [context, config]);
 
         /// <summary>
         /// Sets up the configuration for the builder itself to initialize the <see cref="IHostEnvironment"/>.
         /// </summary>
         /// <param name="config">The <see cref="IConfigurationBuilder"/>.</param>
         /// <remarks>This is intended to be invoked by the <see cref="IHostBuilder.ConfigureHostConfiguration(System.Action{IConfigurationBuilder})"/>.</remarks>
-        public void ConfigureHostConfiguration(IConfigurationBuilder config) => _mi2?.Invoke(_instance, new object[] { config });
+        public void ConfigureHostConfiguration(IConfigurationBuilder config) => _mi2?.Invoke(_instance, [config]);
 
         /// <summary>
         /// Adds services to the container.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <remarks>This is intended to be invoked by the <see cref="IHostBuilder.ConfigureServices(System.Action{HostBuilderContext, IServiceCollection})"/>.</remarks>
-        public void ConfigureServices(IServiceCollection services) => _mi3?.Invoke(_instance, new object[] { services });
+        public void ConfigureServices(IServiceCollection services) => _mi3?.Invoke(_instance, [services]);
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Enables further configuration of the <see cref="IHostApplicationBuilder"/> after it has been created/pre-configured.
+        /// </summary>
+        /// <param name="builder">The <see cref="IHostApplicationBuilder"/></param>
+        public void ConfigureApplication(IHostApplicationBuilder builder) => _mi4?.Invoke(_instance, [builder]);
+#endif
     }
 }

--- a/tests/UnitTestEx.Api/Controllers/PersonController.cs
+++ b/tests/UnitTestEx.Api/Controllers/PersonController.cs
@@ -44,7 +44,7 @@ namespace UnitTestEx.Api.Controllers
         [HttpGet("")]
         public IActionResult GetByArgs(string firstName, string lastName, [FromQuery] List<int> id = default)
         {
-            return new ObjectResult($"{firstName}-{lastName}-{string.Join(",", id)}");
+            return new ObjectResult($"{firstName}-{lastName}-{(id is null ? "" : string.Join(",", id))}");
         }
 
         [HttpPost("{id}")]

--- a/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
@@ -39,7 +40,7 @@ namespace UnitTestEx.NUnit.Test.Other
         [Test]
         public void Run_Service()
         {
-            using var test = GenericTester.Create().ConfigureServices(services => services.AddSingleton<Gin>());
+            using var test = GenericTester.Create<EntryPoint>();
 
             test.Run<Gin, int>(gin => gin.Pour())
                 .AssertSuccess()
@@ -82,5 +83,16 @@ namespace UnitTestEx.NUnit.Test.Other
         public Task ShakeAsync() => Task.CompletedTask;
         public int Pour() => 1;
         public Task<int> PourAsync() => Task.FromResult(1);
+    }
+
+    public class EntryPoint
+    {
+        //public void ConfigureAppConfiguration(HostBuilderContext context, IConfigurationBuilder config) { }
+
+        //public void ConfigureHostConfiguration(IConfigurationBuilder config) { }
+
+        //public void ConfigureServices(IServiceCollection services) { }
+
+        public void ConfigureApplication(IHostApplicationBuilder builder) => builder.Services.AddSingleton<Gin>();
     }
 }

--- a/tests/UnitTestEx.NUnit.Test/UnitTestEx.NUnit.Test.csproj
+++ b/tests/UnitTestEx.NUnit.Test/UnitTestEx.NUnit.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/tests/UnitTestEx.Xunit.Test/UnitTestEx.Xunit.Test.csproj
+++ b/tests/UnitTestEx.Xunit.Test/UnitTestEx.Xunit.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- *Enhancement:* The `GenericTester` where using `.NET8.0` and above will leverage the new `IHostApplicationBuilder` versus existing `IHostBuilder` (see Microsoft [documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/generic-host) and [recommendation](https://github.com/dotnet/runtime/discussions/81090#discussioncomment-4784551)). Additionally, if a `TEntryPoint` is specified with a method signature of `public void ConfigureApplication(IHostApplicationBuilder builder)` then this will be automatically invoked during host instantiation. This is a non-breaking change as largely internal.