### PR TITLE
V5.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Explicit MSTest test
       run: |
-        cp tests/UnitTestEx.Api/bin/Debug/net6.0/UnitTestEx.Api.deps.json tests/UnitTestEx.MSTest.Test/bin/Debug/net8.0
+        cp tests/UnitTestEx.Api/bin/Debug/net8.0/UnitTestEx.Api.deps.json tests/UnitTestEx.MSTest.Test/bin/Debug/net8.0
         cd tests/UnitTestEx.MSTest.Test/bin/Debug/net8.0
         dotnet test UnitTestEx.MSTest.Test.dll --no-build --verbosity normal
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
 
     - name: Explicit MSTest test
       run: |
-        cp tests/UnitTestEx.Api/bin/Debug/net6.0/UnitTestEx.Api.deps.json tests/UnitTestEx.MSTest.Test/bin/Debug/net6.0
-        cd tests/UnitTestEx.MSTest.Test/bin/Debug/net6.0
+        cp tests/UnitTestEx.Api/bin/Debug/net6.0/UnitTestEx.Api.deps.json tests/UnitTestEx.MSTest.Test/bin/Debug/net8.0
+        cd tests/UnitTestEx.MSTest.Test/bin/Debug/net8.0
         dotnet test UnitTestEx.MSTest.Test.dll --no-build --verbosity normal
 
     - name: Explicit NUnit test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Represents the **NuGet** versions.
 - *Enhancement:* Added `HttpResultAssertor` for ASP.NET Minimal APIs `Results` (e.g. `Results.Ok()`, `Results.NotFound()`, etc.) to enable assertions via the `ToHttpResponseMessageAssertor`.
 - *Enhancement:* `TesterBase`, `GenericTester` and `TypeTester` updated to support keyed services.
 - *Enhancement:* `GenericTester` and `TypeTester` updated to support the test run execution within a DI scope (using `UseRunAsScoped`).
+- *Enhancement:* Added `TesterBase<TSelf>.Delay` method to enable delays to be easily added in a test where needed.
 - *Fixed:* The `ExpectationsArranger` updated to `Clear` versus `Reset` after an assertion run to ensure no cross-test contamination.
 
 ## v5.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ Represents the **NuGet** versions.
 ## v5.6.0
 - *Enhancement:* The `RunAsync` methods updated to support `ValueTask` as well as `Task` for the `TypeTester` and `GenericTester` (.NET 9+ only).
 - *Enhancement:* Added `HttpResultAssertor` for ASP.NET Minimal APIs `Results` (e.g. `Results.Ok()`, `Results.NotFound()`, etc.) to enable assertions via the `ToHttpResponseMessageAssertor`.
-- *Enhancement:* `TesterBase`, `GenericTester` and `TypeTester` updated to support keyed services.
-- *Enhancement:* `GenericTester` and `TypeTester` updated to support the test run execution within a DI scope (using `UseRunAsScoped`).
-- *Enhancement:* Added `TesterBase<TSelf>.Delay` method to enable delays to be easily added in a test where needed.
+- *Enhancement:* `TesterBase<TSelf>` updated to support keyed services.
+- *Enhancement* `ScopedTypeTester` created to support pre-instantiated scoped service where multiple tests can be run against the same scoped instance. The existing `TypeTester` will continue to create a new non-scoped instance. These now exist on the `TesterBase<TSelf>`.
+- *Enhancement:* Added `TesterBase<TSelf>.Delay` method to enable delays to be added in a test where needed.
 - *Fixed:* The `ExpectationsArranger` updated to `Clear` versus `Reset` after an assertion run to ensure no cross-test contamination.
 
 ## v5.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Represents the **NuGet** versions.
 
+## v5.6.0
+- *Enhancement:* The `RunAsync` methods updated to support `ValueTask` as well as `Task` for the `TypeTester` and `GenericTester` (.NET 9+ only).
+- *Enhancement:* Added `HttpResultAssertor` for ASP.NET Minimal APIs `Results` (e.g. `Results.Ok()`, `Results.NotFound()`, etc.) to enable assertions via the `ToHttpResponseMessageAssertor`.
+- *Enhancement:* `TesterBase`, `GenericTester` and `TypeTester` updated to support keyed services.
+- *Enhancement:* `GenericTester` and `TypeTester` updated to support the test run execution within a DI scope (using `UseRunAsScoped`).
+- *Fixed:* The `ExpectationsArranger` updated to `Clear` versus `Reset` after an assertion run to ensure no cross-test contamination.
+
 ## v5.5.0
 - *Enhancement:* The `GenericTester` where using `.NET8.0` and above will leverage the new `IHostApplicationBuilder` versus existing `IHostBuilder` (see Microsoft [documentation](https://learn.microsoft.com/en-us/dotnet/core/extensions/generic-host) and [recommendation](https://github.com/dotnet/runtime/discussions/81090#discussioncomment-4784551)). Additionally, if a `TEntryPoint` is specified with a method signature of `public void ConfigureApplication(IHostApplicationBuilder builder)` then this will be automatically invoked during host instantiation. This is a non-breaking change as largely internal.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Represents the **NuGet** versions.
 - *Enhancement:* The `RunAsync` methods updated to support `ValueTask` as well as `Task` for the `TypeTester` and `GenericTester` (.NET 9+ only).
 - *Enhancement:* Added `HttpResultAssertor` for ASP.NET Minimal APIs `Results` (e.g. `Results.Ok()`, `Results.NotFound()`, etc.) to enable assertions via the `ToHttpResponseMessageAssertor`.
 - *Enhancement:* `TesterBase<TSelf>` updated to support keyed services.
-- *Enhancement* `ScopedTypeTester` created to support pre-instantiated scoped service where multiple tests can be run against the same scoped instance. The existing `TypeTester` will continue to create a new non-scoped instance. These now exist on the `TesterBase<TSelf>`.
+- *Enhancement* `ScopedTypeTester` created to support pre-instantiated scoped service where multiple tests can be run against the same scoped instance. The existing `TypeTester` will continue to directly execute a one-off scoped instance. These now exist on the `TesterBase<TSelf>` enabling broader usage.
 - *Enhancement:* Added `TesterBase<TSelf>.Delay` method to enable delays to be added in a test where needed.
 - *Fixed:* The `ExpectationsArranger` updated to `Clear` versus `Reset` after an assertion run to ensure no cross-test contamination.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.5.0</Version>
+		<Version>5.6.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/UnitTestEx.sln
+++ b/UnitTestEx.sln
@@ -23,6 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
 		CHANGELOG.md = CHANGELOG.md
+		.github\workflows\ci.yml = .github\workflows\ci.yml
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		Common.targets = Common.targets
 		CONTRIBUTING.md = CONTRIBUTING.md

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
@@ -139,7 +139,7 @@ namespace UnitTestEx.Azure.Functions
                 var ep2 = ep as FunctionsStartup;
                 var ep3 = new EntryPoint(ep);
 
-                return _host = new HostBuilder()
+                _host = new HostBuilder()
                     .UseEnvironment(UnitTestEx.TestSetUp.Environment)
                     .ConfigureLogging((lb) => { lb.SetMinimumLevel(SetUp.MinimumLogLevel); lb.ClearProviders(); lb.AddProvider(LoggerProvider); })
                     .ConfigureHostConfiguration(cb =>
@@ -180,6 +180,10 @@ namespace UnitTestEx.Azure.Functions
                         SetUp.ConfigureServices?.Invoke(sc);
                         AddConfiguredServices(sc);
                     }).Build();
+
+                OnHostStartUp();
+
+                return _host;
             }
         }
 
@@ -229,7 +233,7 @@ namespace UnitTestEx.Azure.Functions
         /// <typeparam name="T">The <see cref="Type"/> to be tested.</typeparam>
         /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The <see cref="TypeTester{TFunction}"/>.</returns>
-        public TypeTester<T> Type<T>(object? serviceKey = null) where T : class => new(this, HostExecutionWrapper(() => GetHost().Services.CreateScope()), serviceKey);
+        public TypeTester<T> Type<T>(object? serviceKey = null) where T : class => new(this, HostExecutionWrapper(() => GetHost().Services), serviceKey);
 
         /// <summary>
         /// Specifies the <i>Function</i> <see cref="Type"/> that utilizes the <see cref="ServiceBusTriggerAttribute"/> that is to be tested.

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
@@ -228,14 +228,6 @@ namespace UnitTestEx.Azure.Functions
         public HttpTriggerTester<TFunction> HttpTrigger<TFunction>() where TFunction : class => new(this, HostExecutionWrapper(() => GetHost().Services.CreateScope()));
 
         /// <summary>
-        /// Enables a specified <see cref="Type"/> (of <typeparamref name="T"/>) to be tested.
-        /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> to be tested.</typeparam>
-        /// <param name="serviceKey">The optional keyed service key.</param>
-        /// <returns>The <see cref="TypeTester{TFunction}"/>.</returns>
-        public TypeTester<T> Type<T>(object? serviceKey = null) where T : class => new(this, HostExecutionWrapper(() => GetHost().Services), serviceKey);
-
-        /// <summary>
         /// Specifies the <i>Function</i> <see cref="Type"/> that utilizes the <see cref="ServiceBusTriggerAttribute"/> that is to be tested.
         /// </summary>
         /// <typeparam name="TFunction">The Function <see cref="Type"/> that utilizes the <see cref="ServiceBusTriggerAttribute"/> to be tested.</typeparam>

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/FunctionTesterBase.cs
@@ -224,11 +224,12 @@ namespace UnitTestEx.Azure.Functions
         public HttpTriggerTester<TFunction> HttpTrigger<TFunction>() where TFunction : class => new(this, HostExecutionWrapper(() => GetHost().Services.CreateScope()));
 
         /// <summary>
-        /// Specifies the <see cref="Type"/> of <typeparamref name="T"/> that is to be tested.
+        /// Enables a specified <see cref="Type"/> (of <typeparamref name="T"/>) to be tested.
         /// </summary>
         /// <typeparam name="T">The <see cref="Type"/> to be tested.</typeparam>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The <see cref="TypeTester{TFunction}"/>.</returns>
-        public TypeTester<T> Type<T>() where T : class => new(this, HostExecutionWrapper(() => GetHost().Services.CreateScope()));
+        public TypeTester<T> Type<T>(object? serviceKey = null) where T : class => new(this, HostExecutionWrapper(() => GetHost().Services.CreateScope()), serviceKey);
 
         /// <summary>
         /// Specifies the <i>Function</i> <see cref="Type"/> that utilizes the <see cref="ServiceBusTriggerAttribute"/> that is to be tested.

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/HttpTriggerTester.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/HttpTriggerTester.cs
@@ -36,7 +36,7 @@ namespace UnitTestEx.Azure.Functions
     /// </list>
     /// The above checks are generally neccessary to assist in ensuring that the function is being invoked correctly given the parameters have to be explicitly passed in separately.
     /// </remarks>
-    public class HttpTriggerTester<TFunction> : HostTesterBase<TFunction>, IExpectations<HttpTriggerTester<TFunction>> where TFunction : class
+    public class HttpTriggerTester<TFunction> : HostTesterBase<TFunction, HttpTriggerTester<TFunction>>, IExpectations<HttpTriggerTester<TFunction>> where TFunction : class
     {
         private bool _methodCheck = true;
         private RouteCheckOption _routeCheckOption = RouteCheckOption.PathAndQuery;
@@ -47,7 +47,7 @@ namespace UnitTestEx.Azure.Functions
         /// </summary>
         /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
         /// <param name="serviceScope">The <see cref="IServiceScope"/>.</param>
-        public HttpTriggerTester(TesterBase owner, IServiceScope serviceScope) : base(owner, serviceScope)
+        public HttpTriggerTester(TesterBase owner, IServiceScope serviceScope) : base(owner, serviceScope.ServiceProvider)
         { 
             ExpectationsArranger = new ExpectationsArranger<HttpTriggerTester<TFunction>>(owner, this);
             this.SetHttpMethodCheck(owner.SetUp);

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/HttpTriggerTester.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/HttpTriggerTester.cs
@@ -448,9 +448,9 @@ namespace UnitTestEx.Azure.Functions
                 }
             }
 
-            Implementor.WriteLine("");
-            Implementor.WriteLine(new string('=', 80));
-            Implementor.WriteLine("");
+            //Implementor.WriteLine("");
+            //Implementor.WriteLine(new string('=', 80));
+            //Implementor.WriteLine("");
         }
     }
 }

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/ServiceBusTriggerTester.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/ServiceBusTriggerTester.cs
@@ -31,7 +31,7 @@ namespace UnitTestEx.Azure.Functions
         /// </summary>
         /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
         /// <param name="serviceScope">The <see cref="IServiceScope"/>.</param>
-        public ServiceBusTriggerTester(TesterBase owner, IServiceScope serviceScope) : base(owner, serviceScope) => ExpectationsArranger = new ExpectationsArranger<ServiceBusTriggerTester<TFunction>>(owner, this);
+        public ServiceBusTriggerTester(TesterBase owner, IServiceScope serviceScope) : base(owner, serviceScope.ServiceProvider) => ExpectationsArranger = new ExpectationsArranger<ServiceBusTriggerTester<TFunction>>(owner, this);
 
         /// <summary>
         /// Gets the <see cref="ExpectationsArranger{TSelf}"/>.
@@ -81,7 +81,7 @@ namespace UnitTestEx.Azure.Functions
 
                 if (validateTriggerProperties && a is not null)
                 {
-                    var config = ServiceScope.ServiceProvider.GetRequiredService<IConfiguration>();
+                    var config = Services.GetRequiredService<IConfiguration>();
                     var sbta = a as Microsoft.Azure.WebJobs.ServiceBusTriggerAttribute;
                     if (sbta is not null)
                         VerifyServiceBusTriggerProperties(config, sbta);

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/ServiceBusTriggerTester.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/ServiceBusTriggerTester.cs
@@ -261,9 +261,9 @@ namespace UnitTestEx.Azure.Functions
             ssba?.LogResult();
             wsba?.LogResult();
 
-            Implementor.WriteLine("");
-            Implementor.WriteLine(new string('=', 80));
-            Implementor.WriteLine("");
+            //Implementor.WriteLine("");
+            //Implementor.WriteLine(new string('=', 80));
+            //Implementor.WriteLine("");
         }
     }
 }

--- a/src/UnitTestEx.Azure.ServiceBus/UnitTestEx.Azure.ServiceBus.csproj
+++ b/src/UnitTestEx.Azure.ServiceBus/UnitTestEx.Azure.ServiceBus.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UnitTestEx.MSTest/WithApiTester.cs
+++ b/src/UnitTestEx.MSTest/WithApiTester.cs
@@ -17,7 +17,7 @@ namespace UnitTestEx
         private ApiTester<TEntryPoint>? _apiTester = ApiTester.Create<TEntryPoint>();
 
         /// <summary>
-        /// Gets the shared <see cref="ApiTester{TEntryPoint}"/> for testing.
+        /// Gets the underlying <see cref="ApiTester{TEntryPoint}"/> for testing.
         /// </summary>
         public ApiTester<TEntryPoint> Test => _apiTester ?? throw new ObjectDisposedException(nameof(Test));
 

--- a/src/UnitTestEx.NUnit/WithApiTester.cs
+++ b/src/UnitTestEx.NUnit/WithApiTester.cs
@@ -17,7 +17,7 @@ namespace UnitTestEx
         private ApiTester<TEntryPoint>? _apiTester = ApiTester.Create<TEntryPoint>();
 
         /// <summary>
-        /// Gets the shared <see cref="ApiTester{TEntryPoint}"/> for testing.
+        /// Gets the underlying <see cref="ApiTester{TEntryPoint}"/> for testing.
         /// </summary>
         public ApiTester<TEntryPoint> Test => _apiTester ?? throw new ObjectDisposedException(nameof(Test));
 

--- a/src/UnitTestEx.Xunit/WithApiTester.cs
+++ b/src/UnitTestEx.Xunit/WithApiTester.cs
@@ -21,7 +21,7 @@ namespace UnitTestEx
         /// <summary>
         /// Initializes a new instance of the <see cref="WithApiTester{TEntryPoint}"/> class.
         /// </summary>
-        /// <param name="fixture">The shared <see cref="ApiTestFixture{TEntryPoint}"/>.</param>
+        /// <param name="fixture">The <see cref="ApiTestFixture{TEntryPoint}"/>.</param>
         /// <param name="output">The <see cref="ITestOutputHelper"/>.</param>
         public WithApiTester(ApiTestFixture<TEntryPoint> fixture, ITestOutputHelper output) : base(output)
         {
@@ -30,7 +30,7 @@ namespace UnitTestEx
         }
 
         /// <summary>
-        /// Gets the shared <see cref="ApiTester{TEntryPoint}"/> for testing.
+        /// Gets the underlying <see cref="ApiTester{TEntryPoint}"/> for testing.
         /// </summary>
         public ApiTester<TEntryPoint> Test { get; }
     }

--- a/src/UnitTestEx.Xunit/WithApiTester.cs
+++ b/src/UnitTestEx.Xunit/WithApiTester.cs
@@ -6,7 +6,9 @@ using UnitTestEx.Xunit.Internal;
 using Xunit;
 using Xunit.Abstractions;
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure; improves usability.
 namespace UnitTestEx
+#pragma warning restore IDE0130
 {
     /// <summary>
     /// Provides a shared <see cref="Test"/> <see cref="ApiTester{TEntryPoint}"/> to enable usage of the same underlying <see cref="ApiTesterBase{TEntryPoint, TSelf}.GetTestServer"/> instance across multiple tests.

--- a/src/UnitTestEx/Abstractions/TestFrameworkImplementor.cs
+++ b/src/UnitTestEx/Abstractions/TestFrameworkImplementor.cs
@@ -44,7 +44,7 @@ namespace UnitTestEx.Abstractions
         public static void SetLocalCreateFactory(Func<TestFrameworkImplementor> createFactory)
         {
             if (_localCreateFactory.Value is not null)
-                throw new InvalidOperationException($"The local {nameof(TestFrameworkImplementor)} factory has already been set.");
+                return;
 
             _localCreateFactory.Value = createFactory ?? throw new ArgumentNullException(nameof(createFactory));
         }

--- a/src/UnitTestEx/Abstractions/TestSharedState.cs
+++ b/src/UnitTestEx/Abstractions/TestSharedState.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace UnitTestEx.Abstractions
 {
@@ -14,7 +15,11 @@ namespace UnitTestEx.Abstractions
     /// </summary>
     public sealed class TestSharedState
     {
+#if NET9_0_OR_GREATER
+        private readonly Lock _lock = new();
+#else
         private readonly object _lock = new();
+#endif
         private readonly ConcurrentDictionary<string, List<(DateTime, string?)>> _logOutput = new();
 
         /// <summary>
@@ -37,7 +42,7 @@ namespace UnitTestEx.Abstractions
 
             lock (_lock)
             {
-                var logs = _logOutput.GetOrAdd(id, _ => new());
+                var logs = _logOutput.GetOrAdd(id, _ => []);
 
                 // Parse in the message date where possible to ensure correct sequencing; assumes date/time is first 25 characters.
                 DateTime now = DateTime.Now;
@@ -80,7 +85,7 @@ namespace UnitTestEx.Abstractions
                 if (!string.IsNullOrEmpty(requestId) && _logOutput.TryRemove(requestId, out var l2) && l2 != null)
                     logs.AddRange(l2);
 
-                return logs.OrderBy(x => x.Item1).Select(x => x.Item2).ToArray();
+                return [.. logs.OrderBy(x => x.Item1).Select(x => x.Item2)];
             }
         }
 

--- a/src/UnitTestEx/Abstractions/TestSharedState.cs
+++ b/src/UnitTestEx/Abstractions/TestSharedState.cs
@@ -85,7 +85,7 @@ namespace UnitTestEx.Abstractions
         }
 
         /// <summary>
-        /// Gets the state extension data that can be used for addition state information (where applicable).
+        /// Gets the state extension data that can be used for additional state information (where applicable).
         /// </summary>
         public ConcurrentDictionary<string, object?> StateData { get; } = new ConcurrentDictionary<string, object?>();
 

--- a/src/UnitTestEx/Abstractions/TesterBase.cs
+++ b/src/UnitTestEx/Abstractions/TesterBase.cs
@@ -28,6 +28,7 @@ namespace UnitTestEx.Abstractions
         private string? _userName;
         private readonly List<Action<IServiceCollection>> _configureServices = [];
         private IEnumerable<KeyValuePair<string, string?>>? _additionalConfiguration;
+        private readonly List<Action> _hostStart = [];
 
         /// <summary>
         /// Static constructor.
@@ -166,7 +167,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Resets the underlying host to instantiate a new instance.
         /// </summary>
-        /// <param name="resetConfiguredServices">Indicates whether to reset the previously configured services.</param>
+        /// <param name="resetConfiguredServices">Indicates whether to reset the previously configured services and start-ups.</param>
         public void ResetHost(bool resetConfiguredServices = false)
         {
             lock (SyncRoot)
@@ -185,13 +186,44 @@ namespace UnitTestEx.Abstractions
         protected abstract void ResetHost();
 
         /// <summary>
+        /// Enables opportunity to execute logic immediately after the underlying host has been started. 
+        /// </summary>
+        /// <remarks>Where overridding ensure the base is invoked first to avoid unintended side-effects as <see cref="TesterBase"/> will invoke the registered <see cref="OnHostStart(Action, bool)"/>.
+        /// <para><i>Note:</i> a host lifetime can span one or more tests so this should not be used for per-test set-up/configuration. Equally, a <see cref="ResetHost()"/> will result in a new host instantiation on first access.</para></remarks>
+        protected virtual void OnHostStartUp()
+        {
+            foreach (var start in _hostStart)
+            {
+                start();
+            }
+        }
+
+        /// <summary>
+        /// Provides an opportunity to execute logic immediately after the underlying host has been started.
+        /// </summary>
+        /// <param name="start">A start <see cref="Action"/>.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the services.</param>
+        /// <remarks>This can be called multiple times prior to the underlying host being instantiated.
+        /// See <see cref="OnHostStartUp"/>.</remarks>
+        protected void OnHostStart(Action start, bool autoResetHost = true)
+        {
+            lock (SyncRoot)
+            {
+                if (autoResetHost)
+                    ResetHost(false);
+
+                _hostStart.Add(start);
+
+            }
+        }
+
+        /// <summary>
         /// Provides an opportunity to further configure the services before the underlying host is instantiated.
         /// </summary>
         /// <param name="configureServices">A delegate for configuring <see cref="IServiceCollection"/>.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the services.</param>
-        /// <remarks>This can be called multiple times prior to the underlying host being instantiated. Internally, the <paramref name="configureServices"/> is queued and then played in order when the host is initially instantiated.
-        /// Once instantiated, further calls will result in a <see cref="InvalidOperationException"/> unless a <see cref="ResetHost(bool)"/> is performed.</remarks>
-        public void ConfigureServices(Action<IServiceCollection> configureServices, bool autoResetHost = true)
+        /// <remarks>This can be called multiple times prior to the underlying host being instantiated. Internally, the <paramref name="configureServices"/> is queued and then played in order when the host is initially instantiated.</remarks>
+        protected void ConfigureServices(Action<IServiceCollection> configureServices, bool autoResetHost = true)
         {
             lock (SyncRoot)
             {

--- a/src/UnitTestEx/Abstractions/TesterBase.cs
+++ b/src/UnitTestEx/Abstractions/TesterBase.cs
@@ -67,7 +67,6 @@ namespace UnitTestEx.Abstractions
             SetUp = TestSetUp.Default.Clone();
             JsonSerializer = SetUp.JsonSerializer;
             JsonComparerOptions = SetUp.JsonComparerOptions;
-            TestSetUp.LogAutoSetUpOutputs(Implementor);
         }
 
         /// <summary>
@@ -253,7 +252,7 @@ namespace UnitTestEx.Abstractions
 
             object? jo = null;
             var content = res.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-            if (!string.IsNullOrEmpty(content) && JsonMediaTypeNames.Contains(res.Content?.Headers?.ContentType?.MediaType))
+            if (!string.IsNullOrEmpty(content) && !string.IsNullOrEmpty(res.Content?.Headers?.ContentType?.MediaType) && JsonMediaTypeNames.Contains(res.Content.Headers.ContentType.MediaType))
             {
                 try
                 {
@@ -270,10 +269,6 @@ namespace UnitTestEx.Abstractions
             }
             else
                 Implementor.WriteLine($"{txt} {(string.IsNullOrEmpty(content) ? "none" : content)}");
-
-            Implementor.WriteLine("");
-            Implementor.WriteLine(new string('=', 80));
-            Implementor.WriteLine("");
         }
 
         #region CreateHttpRequest

--- a/src/UnitTestEx/Abstractions/TesterBaseT.cs
+++ b/src/UnitTestEx/Abstractions/TesterBaseT.cs
@@ -5,7 +5,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using UnitTestEx.Hosting;
 using UnitTestEx.Json;
 
 namespace UnitTestEx.Abstractions
@@ -131,11 +133,23 @@ namespace UnitTestEx.Abstractions
         /// <param name="configureServices">A delegate for configuring <see cref="IServiceCollection"/>.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the services.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
-        /// <remarks>This can be called multiple times prior to the underlying host being instantiated. Internally, the <paramref name="configureServices"/> is queued and then played in order when the host is initially instantiated.
-        /// Once instantiated, further calls will result in a <see cref="InvalidOperationException"/> unless a <see cref="ResetHost(bool)"/> is performed.</remarks>
+        /// <remarks>This can be called multiple times prior to the underlying host being instantiated. Internally, the <paramref name="configureServices"/> is queued and then played in order when the host is initially instantiated.</remarks>
         public new TSelf ConfigureServices(Action<IServiceCollection> configureServices, bool autoResetHost = true)
         {
             base.ConfigureServices(configureServices, autoResetHost);
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Provides an opportunity to execute logic immediately after the underlying host has been started.
+        /// </summary>
+        /// <param name="start">A start <see cref="Action"/>.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the services.</param>
+        /// <remarks>This can be called multiple times prior to the underlying host being instantiated.
+        /// See <see cref="TesterBase.OnHostStartUp"/>.</remarks>
+        public new TSelf OnHostStart(Action start, bool autoResetHost = true)
+        {
+            base.OnHostStart(start, autoResetHost);
             return (TSelf)this;
         }
 
@@ -150,7 +164,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service with a mock object.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/> being mocked.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> being mocked.</typeparam>
         /// <param name="mock">The <see cref="Mock{T}"/>.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -159,7 +173,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a scoped service with a mock object.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/> being mocked.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> being mocked.</typeparam>
         /// <param name="mock">The <see cref="Mock{T}"/>.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -168,7 +182,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a transient service with a mock object.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/> being mocked.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> being mocked.</typeparam>
         /// <param name="mock">The <see cref="Mock{T}"/>.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -177,7 +191,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service <paramref name="instance"/>. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="instance">The instance value.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -186,7 +200,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service using an <paramref name="implementationFactory"/>.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="implementationFactory">The implementation factory.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -195,7 +209,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         public TSelf ReplaceSingleton<TService>(bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceSingleton<TService>(), autoResetHost);
@@ -203,8 +217,8 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="System.Type"/>.</typeparam>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         public TSelf ReplaceSingleton<TService, TImplementation>(bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceSingleton<TService, TImplementation>(), autoResetHost);
@@ -212,7 +226,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service <paramref name="instance"/>. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="instance">The instance value.</param>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
@@ -222,7 +236,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service using an <paramref name="implementationFactory"/>.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="implementationFactory">The implementation factory.</param>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
@@ -232,7 +246,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -241,8 +255,8 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a singleton service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="System.Type"/>.</typeparam>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -251,7 +265,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a scoped service using an <paramref name="implementationFactory"/>.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="implementationFactory">The implementation factory.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -260,7 +274,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a scoped service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         public TSelf ReplaceScoped<TService>(bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceScoped<TService>(), autoResetHost);
@@ -268,8 +282,8 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a scoped service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="System.Type"/>.</typeparam>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         public TSelf ReplaceScoped<TService, TImplementation>(bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceScoped<TService, TImplementation>(), autoResetHost);
@@ -277,7 +291,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a scoped service using an <paramref name="implementationFactory"/>.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="implementationFactory">The implementation factory.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
@@ -287,7 +301,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a scoped service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -296,8 +310,8 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a scoped service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="System.Type"/>.</typeparam>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -306,7 +320,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a transient service using an <paramref name="implementationFactory"/>.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="implementationFactory">The implementation factory.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -315,7 +329,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a transient service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         public TSelf ReplaceTransient<TService>(bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceTransient<TService>(), autoResetHost);
@@ -323,8 +337,8 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a transient service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="System.Type"/>.</typeparam>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         public TSelf ReplaceTransient<TService, TImplementation>(bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceTransient<TService, TImplementation>(), autoResetHost);
@@ -332,7 +346,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a transient service using an <paramref name="implementationFactory"/>.
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="implementationFactory">The implementation factory.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
@@ -342,7 +356,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a transient service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -351,8 +365,8 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Replaces (where existing), or adds, a transient service. 
         /// </summary>
-        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TService">The service <see cref="System.Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="System.Type"/>.</typeparam>
         /// <param name="serviceKey">The service key.</param>
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
@@ -375,7 +389,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Wraps the host execution to perform required start-up style activities; specifically resetting the <see cref="TestSharedState"/>.
         /// </summary>
-        /// <typeparam name="T">The result <see cref="Type"/>.</typeparam>
+        /// <typeparam name="T">The result <see cref="System.Type"/>.</typeparam>
         /// <param name="result">The function to create the result.</param>
         /// <returns>The <paramref name="result"/>.</returns>
         protected T HostExecutionWrapper<T>(Func<T> result)
@@ -383,5 +397,131 @@ namespace UnitTestEx.Abstractions
             SharedState.Reset();
             return result();
         }
+
+        /// <summary>
+        /// Enables a specified <see cref="System.Type"/> (of <typeparamref name="TService"/>) to be tested.
+        /// </summary>
+        /// <typeparam name="TService">The <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="serviceKey">The optional keyed service key.</param>
+        /// <returns>The <see cref="TypeTester{TFunction}"/>.</returns>
+        public TypeTester<TService> Type<TService>(object? serviceKey = null) where TService : class => new(this, HostExecutionWrapper(() => Services), serviceKey);
+
+        /// <summary>
+        /// Enables a specified <see cref="System.Type"/> (of <typeparamref name="TService"/>) to be tested.
+        /// </summary>
+        /// <typeparam name="TService">The <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The <see cref="TypeTester{TFunction}"/>.</returns>
+        public TypeTester<TService> Type<TService>(Func<IServiceProvider, TService> serviceFactory) where TService : class => new(this, HostExecutionWrapper(() => Services), serviceFactory);
+
+        /// <summary>
+        /// Enables a <typeparamref name="TService"/> instance to be tested managed within a <see cref="TesterBase.Services"/> <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="scopedTester">The <see cref="TypeTester{TService}"/> testing function.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ScopedType<TService>(Action<ScopedTypeTester<TService>> scopedTester, object? serviceKey = null) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(scopedTester);
+
+            using var scope = HostExecutionWrapper(Services.CreateScope);
+            var tester = new ScopedTypeTester<TService>(this, scope.ServiceProvider, scope.ServiceProvider.CreateInstance<TService>(serviceKey));
+            scopedTester(tester);
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Enables a <typeparamref name="TService"/> instance to be tested managed within a <see cref="TesterBase.Services"/> <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <param name="scopedTester">The <see cref="TypeTester{TService}"/> testing function.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ScopedType<TService>(Func<IServiceProvider, TService> serviceFactory, Action<ScopedTypeTester<TService>> scopedTester) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(scopedTester);
+            using var scope = HostExecutionWrapper(Services.CreateScope);
+            var tester = new ScopedTypeTester<TService>(this, scope.ServiceProvider, serviceFactory(scope.ServiceProvider));
+            scopedTester(tester);
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Enables a <typeparamref name="TService"/> instance to be tested managed within a <see cref="TesterBase.Services"/> <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="scopedTesterAsync">The <see cref="TypeTester{TService}"/> testing function.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public TSelf ScopedType<TService>(Func<ScopedTypeTester<TService>, Task> scopedTesterAsync, object? serviceKey = null) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(scopedTesterAsync);
+
+            using var scope = HostExecutionWrapper(Services.CreateScope);
+            var tester = new ScopedTypeTester<TService>(this, scope.ServiceProvider, scope.ServiceProvider.CreateInstance<TService>(serviceKey));
+            scopedTesterAsync(tester).GetAwaiter().GetResult();
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Enables a <typeparamref name="TService"/> instance to be tested managed within a <see cref="TesterBase.Services"/> <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <param name="scopedTesterAsync">The <see cref="TypeTester{TService}"/> testing function.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public TSelf ScopedType<TService>(Func<IServiceProvider, TService> serviceFactory, Func<ScopedTypeTester<TService>, Task> scopedTesterAsync) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(scopedTesterAsync);
+            using var scope = HostExecutionWrapper(Services.CreateScope);
+            var tester = new ScopedTypeTester<TService>(this, scope.ServiceProvider, serviceFactory(scope.ServiceProvider));
+            scopedTesterAsync(tester).GetAwaiter().GetResult();
+            return (TSelf)this;
+        }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Enables a <typeparamref name="TService"/> instance to be tested managed within a <see cref="TesterBase.Services"/> <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="scopedTesterAsync">The <see cref="TypeTester{TService}"/> testing function.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        [OverloadResolutionPriority(2)]
+        public TSelf ScopedType<TService>(Func<ScopedTypeTester<TService>, ValueTask> scopedTesterAsync, object? serviceKey = null) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(scopedTesterAsync);
+
+            using var scope = HostExecutionWrapper(Services.CreateScope);
+            var tester = new ScopedTypeTester<TService>(this, scope.ServiceProvider, scope.ServiceProvider.CreateInstance<TService>(serviceKey));
+            scopedTesterAsync(tester).AsTask().GetAwaiter().GetResult();
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Enables a <typeparamref name="TService"/> instance to be tested managed within a <see cref="TesterBase.Services"/> <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <param name="scopedTesterAsync">The <see cref="TypeTester{TService}"/> testing function.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        [OverloadResolutionPriority(2)]
+        public TSelf ScopedType<TService>(Func<IServiceProvider, TService> serviceFactory, Func<ScopedTypeTester<TService>, ValueTask> scopedTesterAsync) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(scopedTesterAsync);
+            using var scope = HostExecutionWrapper(Services.CreateScope);
+            var tester = new ScopedTypeTester<TService>(this, scope.ServiceProvider, serviceFactory(scope.ServiceProvider));
+            scopedTesterAsync(tester).AsTask().GetAwaiter().GetResult();
+            return (TSelf)this;
+        }
+
+#endif
     }
 }

--- a/src/UnitTestEx/Abstractions/TesterBaseT.cs
+++ b/src/UnitTestEx/Abstractions/TesterBaseT.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UnitTestEx.Json;
 
 namespace UnitTestEx.Abstractions
@@ -356,6 +357,20 @@ namespace UnitTestEx.Abstractions
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         public TSelf ReplaceKeyedTransient<TService, TImplementation>(object? serviceKey, bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceKeyedTransient<TService, TImplementation>(serviceKey), autoResetHost);
+
+        /// <summary>
+        /// Delays the execution of the test for the specified <paramref name="duration"/>.
+        /// </summary>
+        /// <param name="duration">The amount of time to delay the operation. Must be a non-negative <see cref="TimeSpan"/>.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf Delay(TimeSpan duration) => Task.Delay(duration).ContinueWith(_ => (TSelf)this).Result;
+
+        /// <summary>
+        /// Delays the execution of the test for the specified <paramref name="durationInMilliseconds"/>.
+        /// </summary>
+        /// <param name="durationInMilliseconds">The amount of time to delay the operation. Must be a non-negative <see cref="int"/>.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf Delay(int durationInMilliseconds) => Delay(TimeSpan.FromMilliseconds(durationInMilliseconds));
 
         /// <summary>
         /// Wraps the host execution to perform required start-up style activities; specifically resetting the <see cref="TestSharedState"/>.

--- a/src/UnitTestEx/Abstractions/TesterBaseT.cs
+++ b/src/UnitTestEx/Abstractions/TesterBaseT.cs
@@ -209,6 +209,45 @@ namespace UnitTestEx.Abstractions
         public TSelf ReplaceSingleton<TService, TImplementation>(bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceSingleton<TService, TImplementation>(), autoResetHost);
 
         /// <summary>
+        /// Replaces (where existing), or adds, a singleton service <paramref name="instance"/>. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="instance">The instance value.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedSingleton<TService>(TService instance, object? serviceKey, bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceKeyedSingleton(serviceKey, _ => instance), autoResetHost);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a singleton service using an <paramref name="implementationFactory"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="implementationFactory">The implementation factory.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedSingleton<TService>(object? serviceKey, Func<IServiceProvider, TService> implementationFactory, bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceKeyedSingleton(serviceKey, implementationFactory), autoResetHost);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a singleton service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedSingleton<TService>(object? serviceKey, bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceKeyedSingleton<TService>(serviceKey), autoResetHost);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a singleton service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedSingleton<TService, TImplementation>(object? serviceKey, bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceKeyedSingleton<TService, TImplementation>(serviceKey), autoResetHost);
+
+        /// <summary>
         /// Replaces (where existing), or adds, a scoped service using an <paramref name="implementationFactory"/>.
         /// </summary>
         /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
@@ -233,6 +272,35 @@ namespace UnitTestEx.Abstractions
         /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         public TSelf ReplaceScoped<TService, TImplementation>(bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceScoped<TService, TImplementation>(), autoResetHost);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a scoped service using an <paramref name="implementationFactory"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="implementationFactory">The implementation factory.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedScoped<TService>(object? serviceKey, Func<IServiceProvider, object?, TService> implementationFactory, bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceKeyedScoped(serviceKey, implementationFactory), autoResetHost);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a scoped service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedScoped<TService>(object? serviceKey, bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceKeyedScoped<TService>(serviceKey), autoResetHost);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a scoped service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedScoped<TService, TImplementation>(object? serviceKey, bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceKeyedScoped<TService, TImplementation>(serviceKey), autoResetHost);
 
         /// <summary>
         /// Replaces (where existing), or adds, a transient service using an <paramref name="implementationFactory"/>.
@@ -261,6 +329,35 @@ namespace UnitTestEx.Abstractions
         public TSelf ReplaceTransient<TService, TImplementation>(bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceTransient<TService, TImplementation>(), autoResetHost);
 
         /// <summary>
+        /// Replaces (where existing), or adds, a transient service using an <paramref name="implementationFactory"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="implementationFactory">The implementation factory.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedTransient<TService>(object? serviceKey, Func<IServiceProvider, object?, TService> implementationFactory, bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceKeyedTransient(serviceKey, implementationFactory), autoResetHost);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a transient service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedTransient<TService>(object? serviceKey, bool autoResetHost = true) where TService : class => ConfigureServices(sc => sc.ReplaceKeyedTransient<TService>(serviceKey), autoResetHost);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a transient service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="autoResetHost">Indicates whether to automatically <see cref="ResetHost(bool)"/> (passing <c>false</c>) when configuring the service.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf ReplaceKeyedTransient<TService, TImplementation>(object? serviceKey, bool autoResetHost = true) where TService : class where TImplementation : class, TService => ConfigureServices(sc => sc.ReplaceKeyedTransient<TService, TImplementation>(serviceKey), autoResetHost);
+
+        /// <summary>
         /// Wraps the host execution to perform required start-up style activities; specifically resetting the <see cref="TestSharedState"/>.
         /// </summary>
         /// <typeparam name="T">The result <see cref="Type"/>.</typeparam>
@@ -268,7 +365,6 @@ namespace UnitTestEx.Abstractions
         /// <returns>The <paramref name="result"/>.</returns>
         protected T HostExecutionWrapper<T>(Func<T> result)
         {
-            TestSetUp.LogAutoSetUpOutputs(Implementor);
             SharedState.Reset();
             return result();
         }

--- a/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
@@ -19,7 +19,7 @@ namespace UnitTestEx.AspNetCore
     /// <summary>
     /// Provides the basic API unit-testing capabilities.
     /// </summary>
-    /// <typeparam name="TEntryPoint">The API startup <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TEntryPoint">The API startup <see cref="System.Type"/>.</typeparam>
     /// <typeparam name="TSelf">The <see cref="ApiTesterBase{TEntryPoint, TSelf}"/> to support inheriting fluent-style method-chaining.</typeparam>
     public abstract class ApiTesterBase<TEntryPoint, TSelf> : TesterBase<TSelf>, IDisposable where TEntryPoint : class where TSelf : ApiTesterBase<TEntryPoint, TSelf> 
     {
@@ -121,7 +121,7 @@ namespace UnitTestEx.AspNetCore
         /// <summary>
         /// Gets the <see cref="ILogger"/> for the specified <typeparamref name="TCategoryName"/> from the underlying <see cref="Services"/>.
         /// </summary>
-        /// <typeparam name="TCategoryName">The <see cref="Type"/> to infer the category name.</typeparam>
+        /// <typeparam name="TCategoryName">The <see cref="System.Type"/> to infer the category name.</typeparam>
         /// <returns>The <see cref="ILogger{TCategoryName}"/>.</returns>
         public ILogger<TCategoryName> GetLogger<TCategoryName>() => Services.GetRequiredService<ILogger<TCategoryName>>();
 
@@ -134,7 +134,7 @@ namespace UnitTestEx.AspNetCore
         /// <summary>
         /// Specify the <see cref="ControllerBase">API Controller</see> to test.
         /// </summary>
-        /// <typeparam name="TController">The API Controller <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TController">The API Controller <see cref="System.Type"/>.</typeparam>
         /// <returns>The <see cref="ControllerTester{TController}"/>.</returns>
         public ControllerTester<TController> Controller<TController>() where TController : ControllerBase => new(this, GetTestServer());
 
@@ -145,18 +145,27 @@ namespace UnitTestEx.AspNetCore
         public HttpTester Http() => new(this, GetTestServer());
 
         /// <summary>
-        /// Enables a test <see cref="HttpRequestMessage"/> to be sent to the underlying <see cref="TestServer"/> with an expected response value <see cref="Type"/>.
+        /// Enables a test <see cref="HttpRequestMessage"/> to be sent to the underlying <see cref="TestServer"/> with an expected response value <see cref="System.Type"/>.
         /// </summary>
-        /// <typeparam name="TResponse">The response value <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TResponse">The response value <see cref="System.Type"/>.</typeparam>
         /// <returns>The <see cref="HttpTester{TResponse}"/>.</returns>
         public HttpTester<TResponse> Http<TResponse>() => new(this, GetTestServer());
 
         /// <summary>
-        /// Specifies the <see cref="Type"/> of <typeparamref name="T"/> that is to be tested.
+        /// Enables a specified <see cref="System.Type"/> (of <typeparamref name="T"/>) to be tested.
         /// </summary>
-        /// <typeparam name="T">The <see cref="Type"/> to be tested.</typeparam>
+        /// <typeparam name="T">The <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The <see cref="TypeTester{TFunction}"/>.</returns>
-        public TypeTester<T> Type<T>() where T : class => new(this, HostExecutionWrapper(Services.CreateScope));
+        public TypeTester<T> Type<T>(object? serviceKey = null) where T : class => new(this, HostExecutionWrapper(Services.CreateScope), serviceKey);
+
+        /// <summary>
+        /// Enables a specified <see cref="System.Type"/> (of <typeparamref name="T"/>) to be tested.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="System.Type"/> to be tested.</typeparam>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="T"/> instance.</param>
+        /// <returns>The <see cref="TypeTester{TFunction}"/>.</returns>
+        public TypeTester<T> Type<T>(Func<IServiceProvider, T> serviceFactory) where T : class => new(this, HostExecutionWrapper(Services.CreateScope), serviceFactory);
 
         /// <summary>
         /// Gets the underlying <see cref="TestServer"/>.

--- a/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
@@ -164,6 +164,8 @@ namespace UnitTestEx.AspNetCore
             /// <inheritdoc/>
             protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
+                TestSetUp.LogAutoSetUpOutputs(_httpTester.Owner.Implementor);
+
                 if (_httpTester.Owner.SetUp.OnBeforeHttpRequestMessageSendAsync != null)
                     await _httpTester.Owner.SetUp.OnBeforeHttpRequestMessageSendAsync(request, _httpTester.UserName, cancellationToken);
 

--- a/src/UnitTestEx/AspNetCore/HttpTesterBaseT2.cs
+++ b/src/UnitTestEx/AspNetCore/HttpTesterBaseT2.cs
@@ -57,6 +57,18 @@ namespace UnitTestEx.AspNetCore
         }
 
         /// <inheritdoc/>
-        protected override Task AssertExpectationsAsync(HttpResponseMessage res) => ExpectationsArranger.AssertAsync(ExpectationsArranger.CreateArgs(LastLogs).AddExtra(res));
+        protected async override Task AssertExpectationsAsync(HttpResponseMessage res)
+        {
+            TValue value = default!;
+            try
+            {
+                var json = await res.Content.ReadAsStringAsync();
+                if (!string.IsNullOrEmpty(json))
+                    value = JsonSerializer.Deserialize<TValue>(json)!;
+            }
+            catch { }
+
+            await ExpectationsArranger.AssertAsync(ExpectationsArranger.CreateValueArgs(LastLogs, value).AddExtra(res));
+        }
     }
 }

--- a/src/UnitTestEx/Assertors/ActionResultAssertor.cs
+++ b/src/UnitTestEx/Assertors/ActionResultAssertor.cs
@@ -333,7 +333,7 @@ namespace UnitTestEx.Assertors
             AssertResultType<ContentResult>();
 
             var cr = (ContentResult)Result;
-            if (expectedValue != null && cr.Content != null && TesterBase.JsonMediaTypeNames.Contains(cr.ContentType))
+            if (expectedValue != null && cr.Content != null && !string.IsNullOrEmpty(cr.ContentType) && TesterBase.JsonMediaTypeNames.Contains(cr.ContentType))
                 return AssertValue(expectedValue, JsonSerializer.Deserialize<TValue>(cr.Content)!, pathsToIgnore);
             else
                 return AssertValue(expectedValue, cr.Content!, pathsToIgnore);

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertor.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertor.cs
@@ -80,7 +80,7 @@ namespace UnitTestEx.Assertors
                 return this;
             }
 
-            if (TesterBase.JsonMediaTypeNames.Contains(Response.Content.Headers?.ContentType?.MediaType))
+            if (!string.IsNullOrEmpty(Response.Content.Headers?.ContentType?.MediaType) && TesterBase.JsonMediaTypeNames.Contains(Response.Content.Headers.ContentType.MediaType!))
             {
                 var json = Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                 if (expectedValue == null)

--- a/src/UnitTestEx/Assertors/HttpResultAssertor.cs
+++ b/src/UnitTestEx/Assertors/HttpResultAssertor.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
+
+#if NET7_0_OR_GREATER
+
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using UnitTestEx.Abstractions;
+
+namespace UnitTestEx.Assertors
+{
+    /// <summary>
+    /// Represents the <see cref="IResult"/> test assert helper; specifically the <see cref="ToHttpResponseMessageAssertor(HttpRequest?)"/>.
+    /// </summary>
+    /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="result">The <see cref="IResult"/>.</param>
+    /// <param name="exception">The <see cref="Exception"/> (if any).</param>
+    public class HttpResultAssertor(TesterBase owner, IResult result, Exception? exception) : AssertorBase<HttpResultAssertor>(owner, exception)
+    {
+        /// <summary>
+        /// Gets the <see cref="IResult"/>.
+        /// </summary>
+        public IResult Result { get; } = result;
+
+        /// <summary>
+        /// Converts the <see cref="IResult"/> to an <see cref="HttpResponseMessageAssertor"/>.
+        /// </summary>
+        /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/> with <see cref="HttpContext"/>; otherwise, will default.</param>
+        /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
+        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor(HttpRequest? httpRequest = null) => ToHttpResponseMessageAssertor(Owner, Result, httpRequest);
+
+        /// <summary>
+        /// Converts the <see cref="ValueAssertor{TValue}"/> to an <see cref="HttpResponseMessageAssertor"/>.
+        /// </summary>
+        /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+        /// <param name="result">The <see cref="IResult"/> to convert.</param>
+        /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/>; otherwise, will default.</param>
+        /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
+        internal static HttpResponseMessageAssertor ToHttpResponseMessageAssertor(TesterBase owner, IResult result, HttpRequest? httpRequest)
+        {
+            var sw = Stopwatch.StartNew();
+            using var ms = new MemoryStream();
+            var context = httpRequest?.HttpContext ?? new DefaultHttpContext { RequestServices = owner.Services };
+            context.Response.Body = ms;
+
+            result.ExecuteAsync(context).GetAwaiter().GetResult();
+
+            var hr = new HttpResponseMessage((System.Net.HttpStatusCode)context.Response.StatusCode);
+            foreach (var h in context.Response.Headers)
+                hr.Headers.TryAddWithoutValidation(h.Key, [.. h.Value]);
+
+            ms.Position = 0;
+            hr.Content = new ByteArrayContent(ms.ToArray());
+
+            hr.Content.Headers.ContentLength = context.Response.ContentLength;
+            if (context.Response.ContentType is not null && System.Net.Http.Headers.MediaTypeHeaderValue.TryParse(context.Response.ContentType, out var ct))
+                hr.Content.Headers.ContentType = ct;
+
+            sw.Stop();
+            owner.LogHttpResponseMessage(hr, sw);
+
+            return new HttpResponseMessageAssertor(owner, hr);
+        }
+    }
+}
+
+#endif

--- a/src/UnitTestEx/Assertors/ValueAssertor.cs
+++ b/src/UnitTestEx/Assertors/ValueAssertor.cs
@@ -111,11 +111,19 @@ namespace UnitTestEx.Assertors
                 if (Value is HttpResponseMessage hrm)
                     return new HttpResponseMessageAssertor(Owner, hrm);
 
-                if (Value is ActionResult ar)
+                if (Value is IActionResult ar)
                     return ActionResultAssertor.ToHttpResponseMessageAssertor(Owner, ar, httpRequest);
+#if NET7_0_OR_GREATER
+                if (Value is IResult ir)
+                    return HttpResultAssertor.ToHttpResponseMessageAssertor(Owner, ir, httpRequest);
+#endif
             }
 
+#if NET7_0_OR_GREATER
+            throw new InvalidOperationException($"Result Type '{typeof(TValue).Name}' must be either a '{nameof(HttpResponseMessage)}', '{nameof(IResult)}' or '{nameof(IActionResult)}', and the value must not be null.");
+#else
             throw new InvalidOperationException($"Result Type '{typeof(TValue).Name}' must be either a '{nameof(HttpResponseMessage)}' or '{nameof(IActionResult)}', and the value must not be null.");
+#endif
         }
     }
 }

--- a/src/UnitTestEx/Expectations/ErrorExpectations.cs
+++ b/src/UnitTestEx/Expectations/ErrorExpectations.cs
@@ -16,6 +16,9 @@ namespace UnitTestEx.Expectations
     /// <param name="tester">The initiating tester.</param>
     public class ErrorExpectations<TTester>(TesterBase owner, TTester tester) : ExpectationsBase<TTester>(owner, tester)
     {
+        /// <inheritdoc/>
+        public override string Title => "Error expectations";
+
         /// <summary>
         /// Gets or sets the expected error (contains) message (as distinct from the <see cref="Errors"/>).
         /// </summary>

--- a/src/UnitTestEx/Expectations/ExceptionExpectations.cs
+++ b/src/UnitTestEx/Expectations/ExceptionExpectations.cs
@@ -15,6 +15,9 @@ namespace UnitTestEx.Expectations
     public class ExceptionExpectations<TTester>(TesterBase owner, TTester tester) : ExpectationsBase<TTester>(owner, tester)
     {
         /// <inheritdoc/>
+        public override string Title => "Exception expectations";
+
+        /// <inheritdoc/>
         public override int Order => int.MinValue;
 
         /// <summary>

--- a/src/UnitTestEx/Expectations/ExpectationsArranger.cs
+++ b/src/UnitTestEx/Expectations/ExpectationsArranger.cs
@@ -70,14 +70,14 @@ namespace UnitTestEx.Expectations
         }
 
         /// <summary>
-        /// Performs the expectations assertion(s) with the specified <paramref name="logs"/> and <paramref name="exception"/>.
+        /// Performs the expectations assertion(s) with the specified <paramref name="logs"/> and <paramref name="exception"/>, and then does a <see cref="Clear"/> (regardless of outcome).
         /// </summary>
         /// <param name="logs">The logs captured.</param>
         /// <param name="exception">The <see cref="Exception"/>.</param>
         public Task AssertAsync(IEnumerable<string?>? logs, Exception? exception = null) => AssertAsync(CreateArgs(logs, exception));
 
         /// <summary>
-        /// Performs the expectations assertion(s) with the specified <paramref name="logs"/>, <paramref name="value"/> and <paramref name="exception"/>.
+        /// Performs the expectations assertion(s) with the specified <paramref name="logs"/>, <paramref name="value"/> and <paramref name="exception"/>, and then does a <see cref="Clear"/> (regardless of outcome).
         /// </summary>
         /// <param name="logs">The logs captured.</param>
         /// <param name="value">The resulting value.</param>
@@ -85,18 +85,25 @@ namespace UnitTestEx.Expectations
         public Task AssertValueAsync(IEnumerable<string?>? logs, object? value, Exception? exception = null) => AssertAsync(CreateValueArgs(logs, value, exception));
 
         /// <summary>
-        /// Performs the expectations assertion(s) for the specified <paramref name="args"/> and then does a <see cref="Reset"/> (regardless of outcome).
+        /// Performs the expectations assertion(s) for the specified <paramref name="args"/> and then does a <see cref="Clear"/> (regardless of outcome).
         /// </summary>
         public async Task AssertAsync(AssertArgs args)
         {
             try
             {
+                if (_expectations.Values.Count > 0)
+                {
+                    Owner.Implementor.WriteLine("");
+                    Owner.Implementor.WriteLine("EXPECTATIONS >");
+                }
+
                 foreach (var assert in _expectations.Values.OrderBy(x => x.Order))
                 {
+                    Owner.Implementor.WriteLine($"> {assert.Title}.");
                     await assert.AssertAsync(args).ConfigureAwait(false);
                 }
             }
-            finally { Reset(); }
+            finally { Clear(); }
         }
 
         /// <summary>
@@ -111,9 +118,13 @@ namespace UnitTestEx.Expectations
         }
 
         /// <summary>
-        /// Clears (removes) any existing expectations.
+        /// <see cref="Reset"/> and clears (removes) any existing expectations.
         /// </summary>
-        public void Clear() => _expectations.Clear();
+        public void Clear()
+        {
+            Reset();
+            _expectations.Clear();
+        }
 
         /// <summary>
         /// Creates a new <see cref="AssertArgs"/>.

--- a/src/UnitTestEx/Expectations/ExpectationsBase.cs
+++ b/src/UnitTestEx/Expectations/ExpectationsBase.cs
@@ -21,6 +21,11 @@ namespace UnitTestEx.Expectations
         public TesterBase Owner { get; } = owner ?? throw new ArgumentNullException(nameof(owner));
 
         /// <summary>
+        /// Gets or sets the title used in the assertion output.
+        /// </summary>
+        public abstract string Title { get; }
+
+        /// <summary>
         /// Gets or sets the order in which the expectation is asserted.
         /// </summary>
         public virtual int Order { get; } = 100;

--- a/src/UnitTestEx/Expectations/HttpResponseMessageExpectations.cs
+++ b/src/UnitTestEx/Expectations/HttpResponseMessageExpectations.cs
@@ -17,6 +17,9 @@ namespace UnitTestEx.Expectations
     {
         private HttpStatusCode? _httpStatusCode;
 
+        /// <inheritdoc/>
+        public override string Title => "HTTP Response Message expectations";
+
         /// <summary>
         /// Expects that the <see cref="HttpResponseMessage.StatusCode"/> is equal to the <paramref name="httpStatusCode"/>.
         /// </summary>

--- a/src/UnitTestEx/Expectations/LoggerExpectations.cs
+++ b/src/UnitTestEx/Expectations/LoggerExpectations.cs
@@ -18,6 +18,9 @@ namespace UnitTestEx.Expectations
     {
         private readonly List<string> _expectTexts = [];
 
+        /// <inheritdoc/>
+        public override string Title => "Logger expectations";
+
         /// <summary>
         /// Expects that the <see cref="ILogger"/> will have logged a message that contains the specified <paramref name="texts"/>.
         /// </summary>

--- a/src/UnitTestEx/Expectations/ValueExpectations.cs
+++ b/src/UnitTestEx/Expectations/ValueExpectations.cs
@@ -20,6 +20,9 @@ namespace UnitTestEx.Expectations
         private Func<TTester, string>? _json;
         private bool _expectNull;
 
+        /// <inheritdoc/>
+        public override string Title => "Value expectations";
+
         /// <summary>
         /// Expects that the result JSON compares to the expected <paramref name="json"/>.
         /// </summary>

--- a/src/UnitTestEx/ExtensionMethods.cs
+++ b/src/UnitTestEx/ExtensionMethods.cs
@@ -62,6 +62,61 @@ namespace UnitTestEx
             return services.AddSingleton<TService, TImplementation>();
         }
 
+        /* Keyed */
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed singleton service <paramref name="instance"/>. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="instance">The instance value.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedSingleton<TService>(this IServiceCollection services, object? serviceKey, TService instance) where TService : class => ReplaceKeyedSingleton(services, serviceKey, _ => instance);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed singleton service using an <paramref name="implementationFactory"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="implementationFactory">The implementation factory.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedSingleton<TService>(this IServiceCollection services, object? serviceKey, Func<IServiceProvider, TService> implementationFactory) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(implementationFactory);
+
+            services.RemoveKeyed<TService>(serviceKey);
+            return services.AddKeyedSingleton(serviceKey, implementationFactory);
+        }
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed singleton service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedSingleton<TService>(this IServiceCollection services, object? serviceKey) where TService : class
+            => ReplaceKeyedSingleton<TService, TService>(services, serviceKey);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed singleton service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedSingleton<TService, TImplementation>(this IServiceCollection services, object? serviceKey) where TService : class where TImplementation : class, TService
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            services.RemoveKeyed<TService>(serviceKey);
+            return services.AddKeyedSingleton<TService, TImplementation>(serviceKey);
+        }
+
         #endregion
 
         #region Scoped
@@ -104,6 +159,51 @@ namespace UnitTestEx
 
             services.Remove<TService>();
             return services.AddScoped<TService, TImplementation>();
+        }
+
+        /* Keyed */
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed scoped service using an <paramref name="implementationFactory"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="implementationFactory">The implementation factory.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedScoped<TService>(this IServiceCollection services, object? serviceKey, Func<IServiceProvider, object?, TService> implementationFactory) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(implementationFactory);
+
+            services.RemoveKeyed<TService>(serviceKey);
+            return services.AddKeyedScoped<TService>(serviceKey, implementationFactory);
+        }
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed scoped service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedScoped<TService>(this IServiceCollection services, object? serviceKey) where TService : class
+            => ReplaceKeyedScoped<TService, TService>(services, serviceKey);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed scoped service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedScoped<TService, TImplementation>(this IServiceCollection services, object? serviceKey) where TService : class where TImplementation : class, TService
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            services.RemoveKeyed<TService>(serviceKey);
+            return services.AddKeyedScoped<TService, TImplementation>(serviceKey);
         }
 
         #endregion
@@ -150,6 +250,51 @@ namespace UnitTestEx
             return services.AddTransient<TService, TImplementation>();
         }
 
+        /* Keyed */
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed transient service using an <paramref name="implementationFactory"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <param name="implementationFactory">The implementation factory.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedTransient<TService>(this IServiceCollection services, object? serviceKey, Func<IServiceProvider, object?, TService> implementationFactory) where TService : class
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(implementationFactory);
+
+            services.RemoveKeyed<TService>(serviceKey);
+            return services.AddKeyedTransient(serviceKey, implementationFactory);
+        }
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed transient service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedTransient<TService>(this IServiceCollection services, object? serviceKey) where TService : class
+            => ReplaceKeyedTransient<TService, TService>(services, serviceKey);
+
+        /// <summary>
+        /// Replaces (where existing), or adds, a keyed transient service. 
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TImplementation">The implementation <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <remarks>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</remarks>
+        public static IServiceCollection ReplaceKeyedTransient<TService, TImplementation>(this IServiceCollection services, object? serviceKey) where TService : class where TImplementation : class, TService
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            services.RemoveKeyed<TService>(serviceKey);
+            return services.AddKeyedTransient<TService, TImplementation>(serviceKey);
+        }
+
         #endregion
 
         /// <summary>
@@ -157,14 +302,21 @@ namespace UnitTestEx
         /// </summary>
         /// <typeparam name="T">The <see cref="Type"/> to instantiate.</typeparam>
         /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>A reference to the newly created object.</returns>
         /// <remarks>Where <see cref="Type"/> <typeparamref name="T"/> not specifically configured within the <paramref name="serviceProvider"/> DI simulatution will occur by performing constructor-based injection for all required parameters.</remarks>
-        public static T CreateInstance<T>(this IServiceProvider serviceProvider) where T : class
+        public static T CreateInstance<T>(this IServiceProvider serviceProvider, object? serviceKey = null) where T : class
         {
             // Try instantiating using service provider and use if successful.
-            var val = (serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider))).GetService<T>();
+            var val = serviceKey is null
+                ? (serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider))).GetService<T>()
+                : (serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider))).GetKeyedService<T>(serviceKey);
+
             if (val != null)
                 return val;
+
+            if (serviceKey is not null)
+                throw new InvalidOperationException($"Unable to instantiate Type '{typeof(T).Name}' with key '{serviceKey}'.");
 
             var type = typeof(T);
             var ctor = type.GetConstructors().FirstOrDefault();
@@ -183,7 +335,7 @@ namespace UnitTestEx
         }
 
         /// <summary>
-        /// Removes all items from the <see cref="IServiceCollection"/> for the specified <typeparamref name="TService"/>.
+        /// Removes the first occurrence from the <see cref="IServiceCollection"/> for the specified <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
@@ -191,6 +343,19 @@ namespace UnitTestEx
         public static bool Remove<TService>(this IServiceCollection services) where TService : class
         {
             var descriptor = (services ?? throw new ArgumentNullException(nameof(services))).FirstOrDefault(d => d.ServiceType == typeof(TService));
+            return descriptor != null && services.Remove(descriptor);
+        }
+
+        /// <summary>
+        /// Removes the first occurrence from the <see cref="IServiceCollection"/> for the specified <typeparamref name="TService"/> and <paramref name="serviceKey"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <returns><c>true</c> if item was successfully removed; otherwise, <c>false</c>. Also returns <c>false</c> where item was not found.</returns>
+        public static bool RemoveKeyed<TService>(this IServiceCollection services, object? serviceKey) where TService : class
+        {
+            var descriptor = (services ?? throw new ArgumentNullException(nameof(services))).FirstOrDefault(d => d.ServiceType == typeof(TService) && d.IsKeyedService && d.ServiceKey == serviceKey);
             return descriptor != null && services.Remove(descriptor);
         }
     }

--- a/src/UnitTestEx/Generic/GenericTesterBase.cs
+++ b/src/UnitTestEx/Generic/GenericTesterBase.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnitTestEx.Abstractions;
 using UnitTestEx.Assertors;
@@ -20,6 +21,35 @@ namespace UnitTestEx.Generic
     public abstract class GenericTesterBase<TEntryPoint, TSelf>(TestFrameworkImplementor implementor) 
         : GenericTesterCore<TEntryPoint, GenericTesterBase<TEntryPoint, TSelf>>(implementor) where TEntryPoint : class where TSelf : GenericTesterBase<TEntryPoint, TSelf>
     {
+        private bool _runAsScoped;
+        private Func<IServiceScope, Task>? _onRunScopeFuncAsync;
+
+        /// <summary>
+        /// Indicates that the underlying <b>Run</b> methods should be scoped (i.e. <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <param name="onRunAsScoped">The optional function to execute before the primary <b>Run*</b> methods when running as scoped.</param>
+        /// <returns>The tester to support fluent-style method-chaining.</returns>
+        /// <remarks>By default the <b>Run</b> methods are not scoped.</remarks>
+        public TSelf UseRunAsScoped(Func<IServiceScope, Task>? onRunAsScoped = null)
+        {
+            _runAsScoped = true;
+            _onRunScopeFuncAsync = onRunAsScoped;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Indicates that the underlying <b>Run</b> methods should be scoped (i.e. <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <param name="runAsScoped"><see langword="true"/> indicates scoped; otherwise, <see langword="false"/>.</param>
+        /// <returns>The tester to support fluent-style method-chaining.</returns>
+        /// <remarks>By default the <b>Run</b> methods are not scoped.</remarks>
+        public TSelf UseRunAsScoped(bool runAsScoped)
+        {
+            _runAsScoped = runAsScoped;
+            _onRunScopeFuncAsync = null;
+            return (TSelf)this;
+        }
+
         /// <summary>
         /// Executes the <paramref name="action"/> that performs the logic.
         /// </summary>
@@ -36,10 +66,25 @@ namespace UnitTestEx.Generic
         /// </summary>
         /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
         /// <param name="action">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
-        public VoidAssertor Run<TService>(Action<TService> action) where TService : class => RunAsync(() =>
+        public VoidAssertor Run<TService>(Action<TService> action, object? serviceKey = null) where TService : class => RunAsync(() =>
         {
-            var service = Services.GetRequiredService<TService>();
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
+            (action ?? throw new ArgumentNullException(nameof(action))).Invoke(service);
+            return Task.CompletedTask;
+        }).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Executes the <paramref name="action"/> that performs the logic.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="action">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        public VoidAssertor Run<TService>(Action<TService> action, Func<IServiceProvider, TService> serviceFactory) where TService : class => RunAsync(() =>
+        {
+            var service = serviceFactory(Services);
             (action ?? throw new ArgumentNullException(nameof(action))).Invoke(service);
             return Task.CompletedTask;
         }).GetAwaiter().GetResult();
@@ -49,37 +94,158 @@ namespace UnitTestEx.Generic
         /// </summary>
         /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
         public VoidAssertor Run(Func<Task> function) => RunAsync(function).GetAwaiter().GetResult();
 
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic.
+        /// </summary>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public VoidAssertor Run(Func<ValueTask> function) => RunAsync(() => function().AsTask()).GetAwaiter().GetResult();
+
+#endif
         /// <summary>
         /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
         /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
-        public VoidAssertor Run<TService>(Func<TService, Task> function) where TService : class
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public VoidAssertor Run<TService>(Func<TService, Task> function, object? serviceKey = null) where TService : class
         {
-            var service = Services.GetRequiredService<TService>();
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
             return RunAsync(() => function(service)).GetAwaiter().GetResult();
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>
         /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
         /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
-        public Task<VoidAssertor> RunAsync<TService>(Func<TService, Task> function) where TService : class
+        [OverloadResolutionPriority(2)]
+        public VoidAssertor Run<TService>(Func<TService, ValueTask> function, object? serviceKey = null) where TService : class
         {
-            var service = Services.GetRequiredService<TService>();
-            return RunAsync(() => function(service));
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
+            return RunAsync(() => function(service).AsTask()).GetAwaiter().GetResult();
         }
+
+#endif
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public VoidAssertor Run<TService>(Func<TService, Task> function, Func<IServiceProvider, TService> serviceFactory) where TService : class
+        {
+            var service = serviceFactory(Services);
+            return RunAsync(() => function(service)).GetAwaiter().GetResult();
+        }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public VoidAssertor Run<TService>(Func<TService, ValueTask> function, Func<IServiceProvider, TService> serviceFactory) where TService : class
+        {
+            var service = serviceFactory(Services);
+            return RunAsync(() => function(service).AsTask()).GetAwaiter().GetResult();
+        }
+
+#endif
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public async Task<VoidAssertor> RunAsync<TService>(Func<TService, Task> function, object? serviceKey = null) where TService : class
+        {
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
+            return await RunAsync(() => function(service)).ConfigureAwait(false);
+        }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public async Task<VoidAssertor> RunAsync<TService>(Func<TService, ValueTask> function, object? serviceKey = null) where TService : class
+        {
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
+            return await RunAsync(() => function(service).AsTask()).ConfigureAwait(false);
+        }
+
+#endif
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public async Task<VoidAssertor> RunAsync<TService>(Func<TService, Task> function, Func<IServiceProvider, TService> serviceFactory) where TService : class
+        {
+            var service = serviceFactory(Services);
+            return await RunAsync(() => function(service)).ConfigureAwait(false);
+        }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public async Task<VoidAssertor> RunAsync<TService>(Func<TService, ValueTask> function, Func<IServiceProvider, TService> serviceFactory) where TService : class
+        {
+            var service = serviceFactory(Services);
+            return await RunAsync(() => function(service).AsTask()).ConfigureAwait(false);
+        }
+
+#endif
 
         /// <summary>
         /// Executes the <paramref name="function"/> that performs the logic.
         /// </summary>
         /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
         public async Task<VoidAssertor> RunAsync(Func<Task> function)
         {
             ArgumentNullException.ThrowIfNull(function);
@@ -90,12 +256,25 @@ namespace UnitTestEx.Generic
             Implementor.WriteLine("GENERIC TESTER...");
             Implementor.WriteLine("");
 
+            await OnBeforeRunAsync().ConfigureAwait(false);
+            if (OnBeforeRunFuncAsync is not null)
+                await OnBeforeRunFuncAsync().ConfigureAwait(false);
+
             Exception? exception = null;
 
+            IServiceScope? scope = null;
             var sw = System.Diagnostics.Stopwatch.StartNew();
 
             try
             {
+                scope = _runAsScoped ? Services.CreateScope() : null;
+                if (scope is not null)
+                {
+                    await OnRunScopeAsync(scope).ConfigureAwait(false);
+                    if (_onRunScopeFuncAsync is not null)
+                        await _onRunScopeFuncAsync(scope).ConfigureAwait(false);
+                }
+
                 await function().ConfigureAwait(false);
             }
             catch (AggregateException aex)
@@ -105,6 +284,10 @@ namespace UnitTestEx.Generic
             catch (Exception ex)
             {
                 exception = ex;
+            }
+            finally
+            {
+                scope?.Dispose();
             }
 
             sw.Stop();
@@ -132,15 +315,22 @@ namespace UnitTestEx.Generic
             else
                 Implementor.WriteLine($"Result: Success");
 
-            Implementor.WriteLine("");
-            Implementor.WriteLine(new string('=', 80));
-            Implementor.WriteLine("");
-
             await ExpectationsArranger.AssertAsync(messages, exception).ConfigureAwait(false);
 
             return new VoidAssertor(this, exception);
         }
 
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic.
+        /// </summary>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public async Task<VoidAssertor> RunAsync(Func<ValueTask> function)
+            => await RunAsync(() => function().AsTask()).ConfigureAwait(false);
+
+#endif
         /// <summary>
         /// Executes the <paramref name="function"/> that performs the logic.
         /// </summary>
@@ -159,10 +349,26 @@ namespace UnitTestEx.Generic
         /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
         /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
         /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
-        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, TValue> function) where TService : class => RunAsync(() =>
+        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, TValue> function, object? serviceKey = null) where TService : class => RunAsync(() =>
         {
-            var service = Services.GetRequiredService<TService>();
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
+            TValue value = (function ?? throw new ArgumentNullException(nameof(function))).Invoke(service);
+            return Task.FromResult(value);
+        }).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
+        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, TValue> function, Func<IServiceProvider, TService> serviceFactory) where TService : class => RunAsync(() =>
+        {
+            var service = serviceFactory(Services);
             TValue value = (function ?? throw new ArgumentNullException(nameof(function))).Invoke(service);
             return Task.FromResult(value);
         }).GetAwaiter().GetResult();
@@ -173,33 +379,162 @@ namespace UnitTestEx.Generic
         /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
         /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
         public ValueAssertor<TValue> Run<TValue>(Func<Task<TValue>> function) => RunAsync(function).GetAwaiter().GetResult();
 
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic.
+        /// </summary>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public ValueAssertor<TValue> Run<TValue>(Func<ValueTask<TValue>> function) => RunAsync(() => function().AsTask()).GetAwaiter().GetResult();
+
+#endif
         /// <summary>
         /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
         /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
         /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
-        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, Task<TValue>> function) where TService : class
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif        
+        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, Task<TValue>> function, object? serviceKey = null) where TService : class
         {
-            var service = Services.GetRequiredService<TService>();
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
             return RunAsync(() => function(service)).GetAwaiter().GetResult();
         }
 
+#if NET9_0_OR_GREATER
+
         /// <summary>
         /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
         /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
         /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
         /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
-        public Task<ValueAssertor<TValue>> RunAsync<TService, TValue>(Func<TService, Task<TValue>> function) where TService : class
+        [OverloadResolutionPriority(2)]
+        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, ValueTask<TValue>> function, object? serviceKey = null) where TService : class
         {
-            var service = Services.GetRequiredService<TService>();
-            return RunAsync(() => function(service));
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
+            return RunAsync(() => function(service).AsTask()).GetAwaiter().GetResult();
         }
+
+#endif
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif        
+        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, Task<TValue>> function, Func<IServiceProvider, TService> serviceFactory) where TService : class
+        {
+            var service = serviceFactory(Services);
+            return RunAsync(() => function(service)).GetAwaiter().GetResult();
+        }
+
+#if NET9_0_OR_GREATER
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public ValueAssertor<TValue> Run<TService, TValue>(Func<TService, ValueTask<TValue>> function, Func<IServiceProvider, TService> serviceFactory) where TService : class
+        {
+            var service = serviceFactory(Services);
+            return RunAsync(() => function(service).AsTask()).GetAwaiter().GetResult();
+        }
+
+#endif
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif     
+        public async Task<ValueAssertor<TValue>> RunAsync<TService, TValue>(Func<TService, Task<TValue>> function, object? serviceKey = null) where TService : class
+        {
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
+            return await RunAsync(() => function(service)).ConfigureAwait(false);
+        }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceKey">The optional keyed service key.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public async Task<ValueAssertor<TValue>> RunAsync<TService, TValue>(Func<TService, ValueTask<TValue>> function, object? serviceKey = null) where TService : class
+        {
+            var service = serviceKey is null ? Services.GetRequiredService<TService>() : Services.GetRequiredKeyedService<TService>(serviceKey);
+            return await RunAsync(() => function(service).AsTask()).ConfigureAwait(false);
+        }
+
+#endif
+
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif     
+        public async Task<ValueAssertor<TValue>> RunAsync<TService, TValue>(Func<TService, Task<TValue>> function, Func<IServiceProvider, TService> serviceFactory) where TService : class
+        {
+            var service = serviceFactory(Services);
+            return await RunAsync(() => function(service)).ConfigureAwait(false);
+        }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic on the specified <typeparamref name="TService"/>.
+        /// </summary>
+        /// <typeparam name="TService">The configured service <see cref="Type"/> to instantiate.</typeparam>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <returns>The resulting <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public async Task<ValueAssertor<TValue>> RunAsync<TService, TValue>(Func<TService, ValueTask<TValue>> function, Func<IServiceProvider, TService> serviceFactory) where TService : class
+        {
+            var service = serviceFactory(Services);
+            return await RunAsync(() => function(service).AsTask()).ConfigureAwait(false);
+        }
+
+#endif
 
         /// <summary>
         /// Executes the <paramref name="function"/> that performs the logic.
@@ -207,6 +542,9 @@ namespace UnitTestEx.Generic
         /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
         /// <param name="function">The function performing the logic.</param>
         /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif     
         public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<Task<TValue>> function)
         {
             ArgumentNullException.ThrowIfNull(function);
@@ -217,13 +555,26 @@ namespace UnitTestEx.Generic
             Implementor.WriteLine("GENERIC TESTER...");
             Implementor.WriteLine("");
 
+            await OnBeforeRunAsync().ConfigureAwait(false);
+            if (OnBeforeRunFuncAsync is not null)
+                await OnBeforeRunFuncAsync().ConfigureAwait(false);
+
             Exception? exception = null;
 
+            IServiceScope? scope = null;
             var sw = System.Diagnostics.Stopwatch.StartNew();
             TValue value = default!;
 
             try
             {
+                scope = _runAsScoped ? Services.CreateScope() : null;
+                if (scope is not null)
+                {
+                    await OnRunScopeAsync(scope).ConfigureAwait(false);
+                    if (_onRunScopeFuncAsync is not null)
+                        await _onRunScopeFuncAsync(scope).ConfigureAwait(false);
+                }
+
                 value = await function().ConfigureAwait(false);
             }
             catch (AggregateException aex)
@@ -233,6 +584,10 @@ namespace UnitTestEx.Generic
             catch (Exception ex)
             {
                 exception = ex;
+            }
+            finally
+            {
+                scope?.Dispose();
             }
 
             sw.Stop();
@@ -270,13 +625,37 @@ namespace UnitTestEx.Generic
                 }
             }
 
-            Implementor.WriteLine("");
-            Implementor.WriteLine(new string('=', 80));
-            Implementor.WriteLine("");
-
             await ExpectationsArranger.AssertAsync(messages, exception).ConfigureAwait(false);
 
             return new ValueAssertor<TValue>(this, value, exception);
         }
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Executes the <paramref name="function"/> that performs the logic.
+        /// </summary>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function performing the logic.</param>
+        /// <returns>The resulting <see cref="ValueAssertor{TValue}"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<ValueTask<TValue>> function)
+            => await RunAsync(() => function().AsTask()).ConfigureAwait(false);
+#endif
+
+        /// <summary>
+        /// Provides an opportunity to perform any pre-run logic.
+        /// </summary>
+        protected virtual Task OnBeforeRunAsync() => Task.CompletedTask;
+
+        /// <summary>
+        /// Gets or sets the function to perform any pre-run logic.
+        /// </summary>
+        public Func<Task>? OnBeforeRunFuncAsync { get; set; }
+
+        /// <summary>
+        /// Provides an opportunity to perform any logic as a result of the <see cref="UseRunAsScoped(bool)"/>.
+        /// </summary>
+        /// <remarks>This is invoked after the <see cref="OnBeforeRunAsync"/>, but before the <b>Run</b> logic.</remarks>
+        protected virtual Task OnRunScopeAsync(IServiceScope scope) => Task.CompletedTask;
     }
 }

--- a/src/UnitTestEx/Generic/GenericTesterBaseT.cs
+++ b/src/UnitTestEx/Generic/GenericTesterBaseT.cs
@@ -144,10 +144,6 @@ namespace UnitTestEx.Generic
                 }
             }
 
-            Implementor.WriteLine("");
-            Implementor.WriteLine(new string('=', 80));
-            Implementor.WriteLine("");
-
             await ExpectationsArranger.AssertAsync(messages, exception).ConfigureAwait(false);
 
             return new ValueAssertor<TValue>(this, value, exception);

--- a/src/UnitTestEx/Generic/GenericTesterCore.cs
+++ b/src/UnitTestEx/Generic/GenericTesterCore.cs
@@ -106,9 +106,10 @@ namespace UnitTestEx.Generic
                 AddConfiguredServices(builder.Services);
 
                 _host = builder.Build();
+                OnHostStartUp();
                 return _host;
 #else
-                return _host ??= Host.CreateDefaultBuilder()
+                _host ??= Host.CreateDefaultBuilder()
                     .UseEnvironment(TestSetUp.Environment)
                     .ConfigureLogging((lb) => { lb.SetMinimumLevel(SetUp.MinimumLogLevel); lb.ClearProviders(); lb.AddProvider(LoggerProvider); })
                     .ConfigureHostConfiguration(cb =>
@@ -138,6 +139,9 @@ namespace UnitTestEx.Generic
                         SetUp.ConfigureServices?.Invoke(sc);
                         AddConfiguredServices(sc);
                     }).Build();
+                
+                OnHostStartUp();
+                return _host;
 #endif
             }
         }

--- a/src/UnitTestEx/Hosting/HostTesterBase.cs
+++ b/src/UnitTestEx/Hosting/HostTesterBase.cs
@@ -25,7 +25,7 @@ namespace UnitTestEx.Hosting
         /// <summary>
         /// Gets the owning <see cref="TesterBase"/>.
         /// </summary>
-        protected TesterBase Owner { get; } = owner ?? throw new ArgumentNullException(nameof(owner));
+        public TesterBase Owner { get; } = owner ?? throw new ArgumentNullException(nameof(owner));
 
         /// <summary>
         /// Gets the <see cref="IServiceScope"/>.
@@ -45,7 +45,7 @@ namespace UnitTestEx.Hosting
         /// <summary>
         /// Create (instantiate) the <typeparamref name="THost"/> using the <see cref="ServiceScope"/> to provide the constructor based dependency injection (DI) values.
         /// </summary>
-        private THost CreateHost() => ServiceScope.ServiceProvider.CreateInstance<THost>();
+        private THost CreateHost(object? serviceKey) => ServiceScope.ServiceProvider.CreateInstance<THost>(serviceKey);
 
         /// <summary>
         /// Orchestrates the execution of a method as described by the <paramref name="expression"/> returning no result.
@@ -85,7 +85,7 @@ namespace UnitTestEx.Hosting
 
             onBeforeRun?.Invoke(@params, paramAttribute, paramValue);
 
-            var h = CreateHost();
+            var h = CreateHost(null);
             var sw = Stopwatch.StartNew();
 
             try
@@ -146,7 +146,7 @@ namespace UnitTestEx.Hosting
 
             onBeforeRun?.Invoke(@params, paramAttribute, paramValue);
 
-            var h = CreateHost();
+            var h = CreateHost(null);
             var sw = Stopwatch.StartNew();
 
             try

--- a/src/UnitTestEx/Hosting/HostTesterBase.cs
+++ b/src/UnitTestEx/Hosting/HostTesterBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -17,25 +18,32 @@ namespace UnitTestEx.Hosting
     /// <summary>
     /// Provides the base host unit-testing capabilities.
     /// </summary>
-    /// <typeparam name="THost">The host <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TService">The host/service <see cref="Type"/>.</typeparam>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
-    /// <param name="serviceScope">The <see cref="IServiceScope"/>.</param>
-    public class HostTesterBase<THost>(TesterBase owner, IServiceScope serviceScope) where THost : class
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+    public class HostTesterBase<TService>(TesterBase owner, IServiceProvider serviceProvider) where TService : class
     {
+        private ILogger? _logger;
+
         /// <summary>
         /// Gets the owning <see cref="TesterBase"/>.
         /// </summary>
         public TesterBase Owner { get; } = owner ?? throw new ArgumentNullException(nameof(owner));
 
         /// <summary>
-        /// Gets the <see cref="IServiceScope"/>.
+        /// Gets the <see cref="IServiceProvider"/>.
         /// </summary>
-        protected IServiceScope ServiceScope { get; } = serviceScope ?? throw new ArgumentNullException(nameof(serviceScope));
+        public IServiceProvider Services { get; } = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
         /// <summary>
         /// Gets the <see cref="TestFrameworkImplementor"/>.
         /// </summary>
-        protected TestFrameworkImplementor Implementor => Owner.Implementor;
+        public TestFrameworkImplementor Implementor => Owner.Implementor;
+
+        /// <summary>
+        /// Gets the <see cref="ILogger"/> for the <see cref="HostTesterBase{THost}"/>.
+        /// </summary>
+        public ILogger Logger => _logger ??= Owner.LoggerProvider.CreateLogger(GetType().Name);
 
         /// <summary>
         /// Gets or sets the <see cref="IJsonSerializer"/>.
@@ -43,9 +51,9 @@ namespace UnitTestEx.Hosting
         protected IJsonSerializer JsonSerializer => Owner.JsonSerializer;
 
         /// <summary>
-        /// Create (instantiate) the <typeparamref name="THost"/> using the <see cref="ServiceScope"/> to provide the constructor based dependency injection (DI) values.
+        /// Create (instantiate) the <typeparamref name="TService"/> using the <see cref="Services"/> to provide the constructor based dependency injection (DI) values.
         /// </summary>
-        private THost CreateHost(object? serviceKey) => ServiceScope.ServiceProvider.CreateInstance<THost>(serviceKey);
+        private TService CreateHost(object? serviceKey) => Services.CreateInstance<TService>(serviceKey);
 
         /// <summary>
         /// Orchestrates the execution of a method as described by the <paramref name="expression"/> returning no result.
@@ -54,7 +62,7 @@ namespace UnitTestEx.Hosting
         /// <param name="paramAttributeTypes">The optional parameter <see cref="Attribute"/> <see cref="Type"/>(s) to find.</param>
         /// <param name="onBeforeRun">Action to verify the method parameters prior to method invocation.</param>
         /// <returns>The resulting exception if any and elapsed milliseconds.</returns>
-        protected async Task<(Exception? Exception, double ElapsedMilliseconds)> RunAsync(Expression<Func<THost, Task>> expression, Type[]? paramAttributeTypes, OnBeforeRun? onBeforeRun)
+        protected async Task<(Exception? Exception, double ElapsedMilliseconds)> RunAsync(Expression<Func<TService, Task>> expression, Type[]? paramAttributeTypes, OnBeforeRun? onBeforeRun)
         {
             TestSetUp.LogAutoSetUpOutputs(Implementor);
 
@@ -115,7 +123,7 @@ namespace UnitTestEx.Hosting
         /// <param name="paramAttributeTypes">The optional parameter <see cref="Attribute"/> <see cref="Type"/> array to find.</param>
         /// <param name="onBeforeRun">Action to verify the method parameters prior to method invocation.</param>
         /// <returns>The resulting value, resulting exception if any, and elapsed milliseconds.</returns>
-        protected async Task<(TValue Result, Exception? Exception, double ElapsedMilliseconds)> RunAsync<TValue>(Expression<Func<THost, Task<TValue>>> expression, Type[]? paramAttributeTypes, OnBeforeRun? onBeforeRun)
+        protected async Task<(TValue Result, Exception? Exception, double ElapsedMilliseconds)> RunAsync<TValue>(Expression<Func<TService, Task<TValue>>> expression, Type[]? paramAttributeTypes, OnBeforeRun? onBeforeRun)
         {
             TestSetUp.LogAutoSetUpOutputs(Implementor);
 
@@ -181,8 +189,7 @@ namespace UnitTestEx.Hosting
         /// <param name="expression">The <see cref="Expression"/>.</param>
         internal static MethodCallExpression MethodCallExpressionValidate([NotNull] Expression expression)
         {
-            if (expression == null)
-                throw new ArgumentNullException(nameof(expression));
+            ArgumentNullException.ThrowIfNull(expression, nameof(expression));
 
             if (expression is not LambdaExpression lex)
                 throw new ArgumentException($"Expression must be of Type '{nameof(LambdaExpression)}'.", nameof(expression));

--- a/src/UnitTestEx/Hosting/HostTesterBaseT.cs
+++ b/src/UnitTestEx/Hosting/HostTesterBaseT.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using UnitTestEx.Abstractions;
+
+namespace UnitTestEx.Hosting
+{
+    /// <summary>
+    /// Provides the base host unit-testing capabilities.
+    /// </summary>
+    /// <typeparam name="TService">The host/service <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TSelf">The <see cref="HostTesterBase{THost, TSelf}"/> to support inheriting fluent-style method-chaining.</typeparam>
+    /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+    public class HostTesterBase<TService, TSelf>(TesterBase owner, IServiceProvider serviceProvider) : HostTesterBase<TService>(owner, serviceProvider) where TService : class where TSelf : HostTesterBase<TService, TSelf>
+    {
+    }
+}

--- a/src/UnitTestEx/Hosting/ScopedTypeTester.cs
+++ b/src/UnitTestEx/Hosting/ScopedTypeTester.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using UnitTestEx.Abstractions;
+using UnitTestEx.Assertors;
+using UnitTestEx.Expectations;
+using UnitTestEx.Json;
+
+namespace UnitTestEx.Hosting;
+
+/// <summary>
+/// Provides a pre-<i>scoped</i> <typeparamref name="TService"/> unit-testing capabilities from a parent/owning host (see <see cref="TesterBase"/>).
+/// </summary>
+/// <typeparam name="TService">The service <see cref="Type"/> (must be a <c>class</c>).</typeparam>
+/// <remarks>The scoped <see cref="Service"/> instance lifetime is managed outside of <see cref="ScopedTypeTester{TService}"/> lifetime.</remarks>
+public class ScopedTypeTester<TService> : HostTesterBase<TService, ScopedTypeTester<TService>>, IExpectations<ScopedTypeTester<TService>> where TService : class
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScopedTypeTester{TService}"/> class.
+    /// </summary>
+    /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+    /// <param name="service">The <typeparamref name="TService"/> instance.</param>
+    public ScopedTypeTester(TesterBase owner, IServiceProvider serviceProvider, TService service) : base(owner, serviceProvider)
+    {
+        Service = service ?? throw new ArgumentNullException(nameof(service));
+        ExpectationsArranger = new ExpectationsArranger<ScopedTypeTester<TService>>(owner, this);
+    }
+
+    /// <summary>
+    /// Gets the <typeparamref name="TService"/> instance being tested.
+    /// </summary>
+    public TService Service { get; }
+
+    /// <summary>
+    /// Gets the <see cref="ExpectationsArranger{TSelf}"/>.
+    /// </summary>
+    public ExpectationsArranger<ScopedTypeTester<TService>> ExpectationsArranger { get; }
+
+    /// <summary>
+    /// Runs the synchronous method with no result.
+    /// </summary>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="VoidAssertor"/>.</returns>
+    public VoidAssertor Run(Action<TService> function) => RunAsync(x => { function(x); return Task.CompletedTask; }).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Runs the synchronous method with a result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+    public ValueAssertor<TValue> Run<TValue>(Func<TService, TValue> function) => RunAsync(x => Task.FromResult(function(x))).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Runs the asynchronous method with no result.
+    /// </summary>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+    [OverloadResolutionPriority(1)]
+#endif
+    public VoidAssertor Run(Func<TService, Task> function) => RunAsync(function).GetAwaiter().GetResult();
+
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Runs the asynchronous method with no result.
+    /// </summary>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="VoidAssertor"/>.</returns>
+    [OverloadResolutionPriority(2)]
+    public VoidAssertor Run(Func<TService, ValueTask> function) => RunAsync(v => function(v).AsTask()).GetAwaiter().GetResult();
+
+#endif
+    /// <summary>
+    /// Runs the asynchronous method with no result.
+    /// </summary>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+    [OverloadResolutionPriority(1)]
+#endif
+    public async Task<VoidAssertor> RunAsync(Func<TService, Task> function)
+    {
+        TestSetUp.LogAutoSetUpOutputs(Implementor);
+
+        Exception? ex = null;
+        var sw = Stopwatch.StartNew();
+        LogHeader();
+
+        try
+        {
+            await (function ?? throw new ArgumentNullException(nameof(function)))(Service).ConfigureAwait(false);
+        }
+        catch (AggregateException aex)
+        {
+            ex = aex.InnerException ?? aex;
+        }
+        catch (Exception uex)
+        {
+            ex = uex;
+        }
+        finally
+        {
+            sw.Stop();
+        }
+
+        await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
+        var logs = Owner.SharedState.GetLoggerMessages();
+        LogResult(ex, sw.Elapsed.TotalMilliseconds, logs);
+
+        await ExpectationsArranger.AssertAsync(logs, ex).ConfigureAwait(false);
+
+        return new VoidAssertor(Owner, ex);
+    }
+
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Runs the asynchronous method with no result.
+    /// </summary>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="VoidAssertor"/>.</returns>
+    [OverloadResolutionPriority(2)]
+    public async Task<VoidAssertor> RunAsync(Func<TService, ValueTask> function) => await RunAsync(v => function(v).AsTask()).ConfigureAwait(false);
+
+#endif
+    /// <summary>
+    /// Runs the asynchronous method with a result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+#if NET9_0_OR_GREATER
+    [OverloadResolutionPriority(1)]
+#endif
+    public ValueAssertor<TValue> Run<TValue>(Func<TService, Task<TValue>> function) => RunAsync(function).GetAwaiter().GetResult();
+
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Runs the asynchronous method with a result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+    [OverloadResolutionPriority(2)]
+    public ValueAssertor<TValue> Run<TValue>(Func<TService, ValueTask<TValue>> function) => RunAsync(v => function(v).AsTask()).GetAwaiter().GetResult();
+
+#endif
+    /// <summary>
+    /// Runs the asynchronous method with a result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+#if NET9_0_OR_GREATER
+    [OverloadResolutionPriority(1)]
+#endif
+    public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<TService, Task<TValue>> function)
+    {
+        TestSetUp.LogAutoSetUpOutputs(Implementor);
+
+        TValue result = default!;
+        Exception? ex = null;
+        var sw = Stopwatch.StartNew();
+        LogHeader();
+
+        try
+        {
+            result = await (function ?? throw new ArgumentNullException(nameof(function)))(Service).ConfigureAwait(false);
+        }
+        catch (AggregateException aex)
+        {
+            ex = aex.InnerException ?? aex;
+        }
+        catch (Exception uex)
+        {
+            ex = uex;
+        }
+        finally
+        {
+            sw.Stop();
+        }
+
+        await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
+        var logs = Owner.SharedState.GetLoggerMessages();
+        LogResult(ex, sw.Elapsed.TotalMilliseconds, logs);
+
+        if (ex == null)
+        {
+            if (result is string str)
+                Implementor.WriteLine($"Result: {str}");
+            else if (result is IFormattable ifm)
+                Implementor.WriteLine($"Result: {ifm.ToString(null, CultureInfo.CurrentCulture)}");
+            else
+            {
+                Implementor.WriteLine($"Result: {(result == null ? "<null>" : result.GetType().Name)}");
+                if (result != null)
+                    Implementor.WriteLine(JsonSerializer.Serialize<dynamic>(result, JsonWriteFormat.Indented));
+            }
+        }
+
+        await ExpectationsArranger.AssertValueAsync(logs, result, ex).ConfigureAwait(false);
+
+        return new ValueAssertor<TValue>(Owner, result, ex);
+    }
+
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Runs the asynchronous method with a result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+    /// <param name="function">The function execution.</param>
+    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+    [OverloadResolutionPriority(2)]
+    public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<TService, ValueTask<TValue>> function) => await RunAsync(v => function(v).AsTask()).ConfigureAwait(false);
+
+#endif
+    /// <summary>
+    /// Logs the header.
+    /// </summary>
+    private void LogHeader()
+    {
+        Implementor.WriteLine("");
+        Implementor.WriteLine("TYPE TESTER...");
+        Implementor.WriteLine($"Type: {typeof(TService).Name} [{typeof(TService).FullName}]");
+    }
+
+    /// <summary>
+    /// Log the elapsed execution time.
+    /// </summary>
+    private void LogResult(Exception? ex, double ms, IEnumerable<string?>? logs)
+    {
+        Implementor.WriteLine("");
+        Implementor.WriteLine("LOGGING >");
+        if (logs is not null && logs.Any())
+        {
+            foreach (var msg in logs)
+            {
+                Implementor.WriteLine(msg);
+            }
+        }
+        else
+            Implementor.WriteLine("None.");
+
+        Implementor.WriteLine("");
+        Implementor.WriteLine("RESULT >");
+        Implementor.WriteLine($"Elapsed (ms): {ms}");
+        if (ex != null)
+        {
+            Implementor.WriteLine($"Exception: {ex.Message} [{ex.GetType().Name}]");
+            Implementor.WriteLine(ex.ToString());
+        }
+    }
+}

--- a/src/UnitTestEx/Hosting/TypeTester.cs
+++ b/src/UnitTestEx/Hosting/TypeTester.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnitTestEx.Abstractions;
 using UnitTestEx.Assertors;
@@ -15,29 +16,98 @@ using UnitTestEx.Json;
 namespace UnitTestEx.Hosting
 {
     /// <summary>
-    /// Provides the generic <see cref="Type"/> unit-testing capabilities.
+    /// Provides the generic <typeparamref name="TService"/> <see cref="Type"/> unit-testing capabilities.
     /// </summary>
-    /// <typeparam name="T">The <see cref="Type"/> (must be a <c>class</c>).</typeparam>
-    public class TypeTester<T> : HostTesterBase<T>, IExpectations<TypeTester<T>> where T : class
+    /// <typeparam name="TService">The service <see cref="Type"/> (must be a <c>class</c>).</typeparam>
+    /// <remarks>Note that the <typeparamref name="TService"/> service instance is created on first use and then reused (see <see cref="GetOrCreateService"/>).</remarks>
+    public class TypeTester<TService> : HostTesterBase<TService>, IExpectations<TypeTester<TService>> where TService : class
     {
+        private readonly object? _serviceKey;
+        private readonly Func<IServiceProvider, TService>? _serviceFactory;
+        private TService? _service;
+        private bool _runAsScoped;
+        private Func<IServiceScope, Task>? _onRunScopeFuncAsync;
+
         /// <summary>
         /// Initializes a new <see cref="TypeTester{TFunction}"/> class.
         /// </summary>
         /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
         /// <param name="serviceScope">The <see cref="IServiceScope"/>.</param>
-        public TypeTester(TesterBase owner, IServiceScope serviceScope) : base(owner, serviceScope) => ExpectationsArranger = new ExpectationsArranger<TypeTester<T>>(owner, this);
+        /// <param name="serviceKey">The optional key for a keyed service.</param>
+        public TypeTester(TesterBase owner, IServiceScope serviceScope, object? serviceKey = null) : base(owner, serviceScope)
+        {
+            _serviceKey = serviceKey;
+            ExpectationsArranger = new ExpectationsArranger<TypeTester<TService>>(owner, this);
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="TypeTester{TFunction}"/> class with a factory for creating the <typeparamref name="TService"/> instance.
+        /// </summary>
+        /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+        /// <param name="serviceScope">The <see cref="IServiceScope"/>.</param>
+        /// <param name="serviceFactory">The factory to create the <typeparamref name="TService"/> instance.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public TypeTester(TesterBase owner, IServiceScope serviceScope, Func<IServiceProvider, TService> serviceFactory) : base(owner, serviceScope)
+        {
+            _serviceFactory = serviceFactory ?? throw new ArgumentNullException(nameof(serviceFactory));
+            ExpectationsArranger = new ExpectationsArranger<TypeTester<TService>>(owner, this);
+        }
+
+        /// <summary>
+        /// Indicates that the underlying <b>Run</b> methods should be scoped (i.e. <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <param name="onRunAsScoped">The optional function to execute before the primary <b>Run*</b> methods when running as scoped.</param>
+        /// <returns>The tester to support fluent-style method-chaining.</returns>
+        /// <remarks>By default the <b>Run</b> methods are not scoped.</remarks>
+        public TypeTester<TService> UseRunAsScoped(Func<IServiceScope, Task>? onRunAsScoped = null)
+        {
+            _runAsScoped = true;
+            _onRunScopeFuncAsync = onRunAsScoped;
+            return this;
+        }
+
+        /// <summary>
+        /// Indicates that the underlying <b>Run</b> methods should be scoped (i.e. <see cref="ServiceProviderServiceExtensions.CreateScope(IServiceProvider)"/>.
+        /// </summary>
+        /// <param name="runAsScoped"><see langword="true"/> indicates scoped; otherwise, <see langword="false"/>.</param>
+        /// <returns>The tester to support fluent-style method-chaining.</returns>
+        /// <remarks>By default the <b>Run</b> methods are not scoped.</remarks>
+        public TypeTester<TService> UseRunAsScoped(bool runAsScoped)
+        {
+            _runAsScoped = runAsScoped;
+            _onRunScopeFuncAsync = null;
+            return this;
+        }
 
         /// <summary>
         /// Gets the <see cref="ExpectationsArranger{TSelf}"/>.
         /// </summary>
-        public ExpectationsArranger<TypeTester<T>> ExpectationsArranger { get; }
+        public ExpectationsArranger<TypeTester<TService>> ExpectationsArranger { get; }
+
+        /// <summary>
+        /// Gets or creates the <typeparamref name="TService"/> service instance.
+        /// </summary>
+        /// <remarks>This is intended for advanced scenarios; for the most part the <c>Run</c> or <c>RunAsync</c> methods should be used for testing as these encapsulate logging, expectations and assertions.</remarks>
+        public TService GetOrCreateService() => _service ??= _serviceFactory is null
+            ? ServiceScope.ServiceProvider.CreateInstance<TService>(_serviceKey)
+            : _serviceFactory(ServiceScope.ServiceProvider);
+
+        /// <summary>
+        /// Resets the <typeparamref name="TService"/> service instance.
+        /// </summary>
+        /// <returns>The tester to support fluent-style method-chaining.</returns>
+        public TypeTester<TService> ResetService()
+        {
+            _service = default;
+            return this;
+        }
 
         /// <summary>
         /// Runs the synchronous method with no result.
         /// </summary>
         /// <param name="function">The function execution.</param>
         /// <returns>A <see cref="VoidAssertor"/>.</returns>
-        public VoidAssertor Run(Action<T> function) => RunAsync(x => { function(x); return Task.CompletedTask; }).GetAwaiter().GetResult();
+        public VoidAssertor Run(Action<TService> function) => RunAsync(x => { function(x); return Task.CompletedTask; }).GetAwaiter().GetResult();
 
         /// <summary>
         /// Runs the synchronous method with a result.
@@ -45,28 +115,59 @@ namespace UnitTestEx.Hosting
         /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
         /// <param name="function">The function execution.</param>
         /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
-        public ValueAssertor<TValue> Run<TValue>(Func<T, TValue> function) => RunAsync(x => Task.FromResult(function(x))).GetAwaiter().GetResult();
+        public ValueAssertor<TValue> Run<TValue>(Func<TService, TValue> function) => RunAsync(x => Task.FromResult(function(x))).GetAwaiter().GetResult();
 
         /// <summary>
         /// Runs the asynchronous method with no result.
         /// </summary>
         /// <param name="function">The function execution.</param>
         /// <returns>A <see cref="VoidAssertor"/>.</returns>
-        public VoidAssertor Run(Func<T, Task> function) => RunAsync(function).GetAwaiter().GetResult();
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public VoidAssertor Run(Func<TService, Task> function) => RunAsync(function).GetAwaiter().GetResult();
 
+#if NET9_0_OR_GREATER
         /// <summary>
         /// Runs the asynchronous method with no result.
         /// </summary>
         /// <param name="function">The function execution.</param>
         /// <returns>A <see cref="VoidAssertor"/>.</returns>
-        public async Task<VoidAssertor> RunAsync(Func<T, Task> function)
+        [OverloadResolutionPriority(2)]
+        public VoidAssertor Run(Func<TService, ValueTask> function) => RunAsync(v => function(v).AsTask()).GetAwaiter().GetResult();
+
+#endif
+        /// <summary>
+        /// Runs the asynchronous method with no result.
+        /// </summary>
+        /// <param name="function">The function execution.</param>
+        /// <returns>A <see cref="VoidAssertor"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public async Task<VoidAssertor> RunAsync(Func<TService, Task> function)
         {
+            TestSetUp.LogAutoSetUpOutputs(Implementor);
+
+            IServiceScope? scope = null;
             Exception? ex = null;
             var sw = Stopwatch.StartNew();
             try
             {
                 LogHeader();
-                var f = ServiceScope.ServiceProvider.CreateInstance<T>();
+                await OnBeforeRunAsync().ConfigureAwait(false);
+                if (OnBeforeRunFuncAsync is not null)
+                    await OnBeforeRunFuncAsync().ConfigureAwait(false);
+
+                scope = _runAsScoped ? ServiceScope.ServiceProvider.CreateScope() : null;
+                if (scope is not null)
+                {
+                    await OnRunScopeAsync(scope).ConfigureAwait(false);
+                    if (_onRunScopeFuncAsync is not null)
+                        await _onRunScopeFuncAsync(scope).ConfigureAwait(false);
+                }
+
+                var f = GetOrCreateService();
                 await (function ?? throw new ArgumentNullException(nameof(function)))(f).ConfigureAwait(false);
             }
             catch (AggregateException aex)
@@ -79,42 +180,84 @@ namespace UnitTestEx.Hosting
             }
             finally
             {
+                scope?.Dispose();
                 sw.Stop();
             }
 
             await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
             var logs = Owner.SharedState.GetLoggerMessages();
             LogResult(ex, sw.Elapsed.TotalMilliseconds, logs);
-            LogTrailer();
 
             await ExpectationsArranger.AssertAsync(logs, ex).ConfigureAwait(false);
 
             return new VoidAssertor(Owner, ex);
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>
-        /// Runs the asynchronous method with a result.
+        /// Runs the asynchronous method with no result.
         /// </summary>
-        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
         /// <param name="function">The function execution.</param>
-        /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
-        public ValueAssertor<TValue> Run<TValue>(Func<T, Task<TValue>> function) => RunAsync(function).GetAwaiter().GetResult();
+        /// <returns>A <see cref="VoidAssertor"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public async Task<VoidAssertor> RunAsync(Func<TService, ValueTask> function) => await RunAsync(v => function(v).AsTask()).ConfigureAwait(false);
 
+#endif
         /// <summary>
         /// Runs the asynchronous method with a result.
         /// </summary>
         /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
         /// <param name="function">The function execution.</param>
         /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
-        public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<T, Task<TValue>> function)
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public ValueAssertor<TValue> Run<TValue>(Func<TService, Task<TValue>> function) => RunAsync(function).GetAwaiter().GetResult();
+
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Runs the asynchronous method with a result.
+        /// </summary>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function execution.</param>
+        /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public ValueAssertor<TValue> Run<TValue>(Func<TService, ValueTask<TValue>> function) => RunAsync(v => function(v).AsTask()).GetAwaiter().GetResult();
+
+#endif
+        /// <summary>
+        /// Runs the asynchronous method with a result.
+        /// </summary>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function execution.</param>
+        /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+#if NET9_0_OR_GREATER
+        [OverloadResolutionPriority(1)]
+#endif
+        public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<TService, Task<TValue>> function)
         {
+            TestSetUp.LogAutoSetUpOutputs(Implementor);
+
+            IServiceScope? scope = null;
             TValue result = default!;
             Exception? ex = null;
             var sw = Stopwatch.StartNew();
             try
             {
                 LogHeader();
-                var f = ServiceScope.ServiceProvider.CreateInstance<T>();
+                await OnBeforeRunAsync().ConfigureAwait(false);
+                if (OnBeforeRunFuncAsync is not null)
+                    await OnBeforeRunFuncAsync().ConfigureAwait(false);
+
+                scope = _runAsScoped ? ServiceScope.ServiceProvider.CreateScope() : null;
+                if (scope is not null)
+                {
+                    await OnRunScopeAsync(scope).ConfigureAwait(false);
+                    if (_onRunScopeFuncAsync is not null)
+                        await _onRunScopeFuncAsync(scope).ConfigureAwait(false);
+                }
+
+                var f = GetOrCreateService();
                 result = await (function ?? throw new ArgumentNullException(nameof(function)))(f).ConfigureAwait(false);
             }
             catch (AggregateException aex)
@@ -127,6 +270,7 @@ namespace UnitTestEx.Hosting
             }
             finally
             {
+                scope?.Dispose();
                 sw.Stop();
             }
 
@@ -148,13 +292,22 @@ namespace UnitTestEx.Hosting
                 }
             }
 
-            LogTrailer();
-
             await ExpectationsArranger.AssertValueAsync(logs, result, ex).ConfigureAwait(false);
 
             return new ValueAssertor<TValue>(Owner, result, ex);
         }
 
+#if NET9_0_OR_GREATER
+        /// <summary>
+        /// Runs the asynchronous method with a result.
+        /// </summary>
+        /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+        /// <param name="function">The function execution.</param>
+        /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+        [OverloadResolutionPriority(2)]
+        public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<TService, ValueTask<TValue>> function) => await RunAsync(v => function(v).AsTask()).ConfigureAwait(false);
+
+#endif
         /// <summary>
         /// Logs the header.
         /// </summary>
@@ -162,7 +315,7 @@ namespace UnitTestEx.Hosting
         {
             Implementor.WriteLine("");
             Implementor.WriteLine("TYPE TESTER...");
-            Implementor.WriteLine($"Type: {typeof(T).Name} [{typeof(T).FullName}]");
+            Implementor.WriteLine($"Type: {typeof(TService).Name} [{typeof(TService).FullName}]");
         }
 
         /// <summary>
@@ -193,13 +346,19 @@ namespace UnitTestEx.Hosting
         }
 
         /// <summary>
-        /// Log the trailer.
+        /// Provides an opportunity to perform any pre-run logic.
         /// </summary>
-        private void LogTrailer()
-        {
-            Implementor.WriteLine("");
-            Implementor.WriteLine(new string('=', 80));
-            Implementor.WriteLine("");
-        }
+        protected virtual Task OnBeforeRunAsync() => Task.CompletedTask;
+
+        /// <summary>
+        /// Gets or sets the function to perform any pre-run logic.
+        /// </summary>
+        public Func<Task>? OnBeforeRunFuncAsync { get; set; }
+
+        /// <summary>
+        /// Provides an opportunity to perform any logic as a result of the <see cref="UseRunAsScoped"/>.
+        /// </summary>
+        /// <remarks>This is invoked after the <see cref="OnBeforeRunAsync"/>, but before the <b>Run</b> logic.</remarks>
+        protected virtual Task OnRunScopeAsync(IServiceScope scope) => Task.CompletedTask;
     }
 }

--- a/src/UnitTestEx/Json/JsonElementComparerOptions.cs
+++ b/src/UnitTestEx/Json/JsonElementComparerOptions.cs
@@ -23,6 +23,11 @@ namespace UnitTestEx.Json
         }
 
         /// <summary>
+        /// Gets or sets the optional preamble text that provides context for the comparison in the resulting error message.
+        /// </summary>
+        public string? PreambleText { get; set; } = null;
+
+        /// <summary>
         /// Gets or sets the <see cref="IEqualityComparer{String}"/> to use for comparing JSON paths.
         /// </summary>
         /// <remarks>Defaults to <see cref="StringComparer.OrdinalIgnoreCase"/>.</remarks>

--- a/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
@@ -226,7 +226,7 @@ namespace UnitTestEx.Mocking
             if (_content == null)
                 return "'No content'";
 
-            if (TesterBase.JsonMediaTypeNames.Contains(_mediaType?.ToLowerInvariant()) && _content is not string)
+            if (!string.IsNullOrEmpty(_mediaType) && TesterBase.JsonMediaTypeNames.Contains(_mediaType.ToLowerInvariant()) && _content is not string)
                 return JsonSerializer.Serialize(_content);
 
             return _content.ToString();

--- a/src/UnitTestEx/ObjectComparer.cs
+++ b/src/UnitTestEx/ObjectComparer.cs
@@ -51,7 +51,12 @@ namespace UnitTestEx
 
             var cr = new JsonElementComparer(o).CompareValue(expected, actual, pathsToIgnore);
             if (cr.HasDifferences)
-                TestFrameworkImplementor.Create().AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
+            {
+                if (o.PreambleText is null)
+                    TestFrameworkImplementor.Create().AssertFail($"Expected and Actual values are not equal:{Environment.NewLine}{cr}");
+                else
+                    TestFrameworkImplementor.Create().AssertFail($"{o.PreambleText}{Environment.NewLine}Expected and Actual values are not equal:{Environment.NewLine}{cr}");
+            }
         }
 
         /// <summary>

--- a/src/UnitTestEx/TestSetUp.cs
+++ b/src/UnitTestEx/TestSetUp.cs
@@ -114,6 +114,11 @@ namespace UnitTestEx
         /// <param name="implementor">The <see cref="TestFrameworkImplementor"/>.</param>
         public static void LogAutoSetUpOutputs(TestFrameworkImplementor implementor)
         {
+            // Top-level test dividing line!
+            implementor.WriteLine("");
+            implementor.WriteLine(new string('=', 80));
+
+            // Output any previously registered auto set up outputs.
             var output = GetAutoSetUpOutput();
             while (!string.IsNullOrEmpty(output))
             {

--- a/src/UnitTestEx/TestSetUp.cs
+++ b/src/UnitTestEx/TestSetUp.cs
@@ -117,6 +117,7 @@ namespace UnitTestEx
             // Top-level test dividing line!
             implementor.WriteLine("");
             implementor.WriteLine(new string('=', 80));
+            implementor.WriteLine($"Timestamp: {DateTime.UtcNow} (UTC).");
 
             // Output any previously registered auto set up outputs.
             var output = GetAutoSetUpOutput();

--- a/tests/UnitTestEx.Api/Controllers/ProductController.cs
+++ b/tests/UnitTestEx.Api/Controllers/ProductController.cs
@@ -22,7 +22,7 @@ namespace UnitTestEx.Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<IActionResult> Get(string id)
+        public async ValueTask<IActionResult> Get(string id)
         {
             var result = await _httpClient.GetAsync($"products/{id}").ConfigureAwait(false);
             if (result.StatusCode == HttpStatusCode.NotFound)
@@ -62,9 +62,9 @@ namespace UnitTestEx.Api.Controllers
         }
 
         [HttpGet("test/problem")]
-        public Task<IActionResult> GetProblem()
+        public ValueTask<IActionResult> GetProblem()
         {
-            return Task.FromResult((IActionResult)new JsonResult(new HttpValidationProblemDetails(new Dictionary<string, string[]> { { "id", ["Not specified."] } } )));
+            return ValueTask.FromResult((IActionResult)new JsonResult(new HttpValidationProblemDetails(new Dictionary<string, string[]> { { "id", ["Not specified."] } } )));
         }
     }
 }

--- a/tests/UnitTestEx.Api/UnitTestEx.Api.csproj
+++ b/tests/UnitTestEx.Api/UnitTestEx.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.14" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.18" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/tests/UnitTestEx.MSTest.Test/Other/GenericTest.cs
+++ b/tests/UnitTestEx.MSTest.Test/Other/GenericTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Threading.Tasks;
 using UnitTestEx.Expectations;
 
 namespace UnitTestEx.MSTest.Test.Other
@@ -19,9 +20,21 @@ namespace UnitTestEx.MSTest.Test.Other
         [TestMethod]
         public void Run_Exception()
         {
+            static Func<Task> ThrowBadness() => () => throw new DivideByZeroException("Badness.");
+
             using var test = GenericTester.Create();
             test.ExpectError("Badness.")
-                .Run(() => throw new DivideByZeroException("Badness."));
+                .Run(ThrowBadness());
+        }
+
+        [TestMethod]
+        public void Run_Exception_ValueTask()
+        {
+            static Func<ValueTask> ThrowBadness() => () => throw new DivideByZeroException("Badness.");
+
+            using var test = GenericTester.Create();
+            test.ExpectError("Badness.")
+                .Run(ThrowBadness());
         }
     }
 }

--- a/tests/UnitTestEx.MSTest.Test/UnitTestEx.MSTest.Test.csproj
+++ b/tests/UnitTestEx.MSTest.Test/UnitTestEx.MSTest.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <IsTestProject>true</IsTestProject>

--- a/tests/UnitTestEx.NUnit.Test/Other/ExpectationsTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/ExpectationsTest.cs
@@ -13,10 +13,10 @@ namespace UnitTestEx.NUnit.Test.Other
         public void ExceptionSuccess_ExpectException_Any()
         {
             var gt = GenericTester.Create().ExpectException().Any();
-
             var ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, null)));
             Assert.That(ex.Message, Is.EqualTo("Expected an exception; however, the execution was successful."));
 
+            gt.ExpectException().Any();
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, new DivideByZeroException()));
         }
 
@@ -25,8 +25,11 @@ namespace UnitTestEx.NUnit.Test.Other
         {
             var gt = GenericTester.Create().ExpectException("error");
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, new DivideByZeroException("error")));
+
+            gt.ExpectException("error");
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, new DivideByZeroException("Error")));
 
+            gt.ExpectException("error");
             var ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, new DivideByZeroException("not ok"))));
             Assert.That(ex.Message, Is.EqualTo("Expected Exception message 'error' is not contained within 'not ok'."));
         }
@@ -35,13 +38,14 @@ namespace UnitTestEx.NUnit.Test.Other
         public void ExceptionSuccess_ExpectException_Type()
         {
             var gt = GenericTester.Create().ExpectException().Type<DivideByZeroException>();
-
             var ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, null)));
             Assert.That(ex.Message, Is.EqualTo("Expected an exception; however, the execution was successful."));
 
+            gt.ExpectException().Type<DivideByZeroException>();
             ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, new NotSupportedException())));
             Assert.That(ex.Message, Is.EqualTo("Expected Exception type 'DivideByZeroException' not equal to actual 'NotSupportedException'."));
 
+            gt.ExpectException().Type<DivideByZeroException>();
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, new DivideByZeroException()));
         }
 
@@ -49,7 +53,6 @@ namespace UnitTestEx.NUnit.Test.Other
         public void ExpectError_None()
         {
             var gt = GenericTester.Create().ExpectError("No error will be raised.");
-
             var ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertAsync(null, null)));
             Assert.That(ex.Message, Is.EqualTo("Expected one or more errors; however, none were returned."));
         }
@@ -60,11 +63,13 @@ namespace UnitTestEx.NUnit.Test.Other
             var gt = GenericTester.CreateFor<string>().ExpectValue("bob");
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, "bob"));
 
+            gt.ExpectValue("bob");
             var ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, "jenny")));
-            Assert.That(ex.Message.Contains("Value is not equal: \"bob\" != \"jenny\"."), Is.True);
+            Assert.That(ex.Message, Does.Contain("Value is not equal: \"bob\" != \"jenny\"."));
 
+            gt.ExpectValue("bob");
             ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, null)));
-            Assert.That(ex.Message.Contains("Kind is not equal: String != Null."), Is.True);
+            Assert.That(ex.Message, Does.Contain("Kind is not equal: String != Null."));
         }
 
         [Test]
@@ -73,23 +78,27 @@ namespace UnitTestEx.NUnit.Test.Other
             var gt = GenericTester.CreateFor<string>().ExpectValue(_ => "bob");
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, "bob"));
 
+            gt.ExpectValue(_ => "bob");
             var ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, "jenny")));
-            Assert.That(ex.Message.Contains("Value is not equal: \"bob\" != \"jenny\"."), Is.True);
+            Assert.That(ex.Message, Does.Contain("Value is not equal: \"bob\" != \"jenny\"."));
 
+            gt.ExpectValue(_ => "bob");
             ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, null)));
-            Assert.That(ex.Message.Contains("Kind is not equal: String != Null."), Is.True);
+            Assert.That(ex.Message, Does.Contain("Kind is not equal: String != Null."));
         }
 
         [Test]
         public void ExpectValueComplex()
         {
             var gt = GenericTester.CreateFor<Entity<int>>().ExpectValue(new Entity<int> { Id = 88, Name = "bob" });
-
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, new Entity<int> { Id = 88, Name = "bob" }));
+
+            gt.ExpectValue(new Entity<int> { Id = 88, Name = "bob" });
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, new { Id = 88, Name = "bob" }));
 
+            gt.ExpectValue(new Entity<int> { Id = 88, Name = "bob" });
             var ex = Assert.Throws<Exception>(() => ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, new { Id = 99, Name = "bob" })));
-            Assert.That(ex.Message.Contains("Path '$.id': Value is not equal: 88 != 99."), Is.True);
+            Assert.That(ex.Message, Does.Contain("Path '$.id': Value is not equal: 88 != 99."));
 
             gt = GenericTester.CreateFor<Entity<int>>().ExpectValue(new Entity<int> { Id = 88, Name = "bob" }, "id");
             ArrangerAssert(async () => await gt.ExpectationsArranger.AssertValueAsync(null, new { Id = 99, Name = "bob" }));

--- a/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -313,7 +314,7 @@ namespace UnitTestEx.NUnit.Test
         {
             using var test = ApiTester.Create<Startup>();
             var hr = test.CreateHttpRequest(HttpMethod.Get, "Person/1");
-            hr.HttpContext.Response.Headers.Add("X-Test", "Test");
+            hr.HttpContext.Response.Headers.Append("X-Test", "Test");
 
             var iar = new OkResult();
 

--- a/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
@@ -16,7 +16,7 @@ namespace UnitTestEx.NUnit.Test
         [Test]
         public async Task Get_Test1()
         {
-            using var test = ApiTester.Create<Startup>();
+            using var test = ApiTester.Create<Startup>().Delay(1000);
             (await test.Controller<PersonController>()
                 .ExpectLogContains("Get using identifier 1")
                 .RunAsync(c => c.Get(1)))

--- a/tests/UnitTestEx.NUnit.Test/UnitTestEx.NUnit.Test.csproj
+++ b/tests/UnitTestEx.NUnit.Test/UnitTestEx.NUnit.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/tests/UnitTestEx.Xunit.Test/Other/GenericTest.cs
+++ b/tests/UnitTestEx.Xunit.Test/Other/GenericTest.cs
@@ -1,4 +1,6 @@
-﻿using UnitTestEx.Expectations;
+﻿using System;
+using System.Threading.Tasks;
+using UnitTestEx.Expectations;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,9 +22,11 @@ namespace UnitTestEx.Xunit.Test.Other
         [Fact]
         public void Run_Exception()
         {
+            static Func<Task> ThrowBadness() => () => throw new DivideByZeroException("Badness.");
+
             using var test = GenericTester.Create();
             test.ExpectError("Badness.")
-                .Run(() => throw new System.ArithmeticException("Badness."));
+                .Run(ThrowBadness());
         }
     }
 }

--- a/tests/UnitTestEx.Xunit.Test/UnitTestEx.Xunit.Test.csproj
+++ b/tests/UnitTestEx.Xunit.Test/UnitTestEx.Xunit.Test.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- *Enhancement:* The `RunAsync` methods updated to support `ValueTask` as well as `Task` for the `TypeTester` and `GenericTester` (.NET 9+ only).
- *Enhancement:* Added `HttpResultAssertor` for ASP.NET Minimal APIs `Results` (e.g. `Results.Ok()`, `Results.NotFound()`, etc.) to enable assertions via the `ToHttpResponseMessageAssertor`.
- *Enhancement:* `TesterBase<TSelf>` updated to support keyed services.
- *Enhancement* `ScopedTypeTester` created to support pre-instantiated scoped service where multiple tests can be run against the same scoped instance. The existing `TypeTester` will continue to directly execute a one-off scoped instance. These now exist on the `TesterBase<TSelf>` enabling broader usage.
- *Enhancement:* Added `TesterBase<TSelf>.Delay` method to enable delays to be added in a test where needed.
- *Fixed:* The `ExpectationsArranger` updated to `Clear` versus `Reset` after an assertion run to ensure no cross-test contamination.