### PR TITLE
v5.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.9.2
+- *Fixed:* The `MockHttpClientRequest` now resets the internal count state when overridding a response to ensure `Verify()` functions correctly.
+
 ## v5.9.1
 - *Fixed:* The `MockHttpClientRequest` now caches the response content internally, and creates a new `HttpContent` instance for each request to ensure that the content can be read multiple times across multiple requests (where applicable); avoids potential object disposed error.
 - *Fixed:* The `MockHttpClient.Reset()` was incorrectly resetting the `MockHttpClient` instance to its default state, but was not resetting the internal request configuration which is used to determine the response. This has now been corrected to reset the internal mocked state only.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.9.1</Version>
+		<Version>5.9.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
@@ -110,6 +110,11 @@ namespace UnitTestEx.Mocking
 
             // Mark as mock complete.
             IsMockComplete = true;
+
+            // Reset counts and indices.
+            Rule.Response?.Count = 0;
+            Rule.ResponsesIndex = 0;
+            Rule.Responses?.ForEach(x => x.Count = 0);
         }
 
         /// <summary>
@@ -152,21 +157,6 @@ namespace UnitTestEx.Mocking
 
             response.ResponseAction?.Invoke(httpResponse);
             return httpResponse;
-        }
-
-        /// <summary>
-        /// Converts the body to a string.
-        /// </summary>
-        private string BodyToString()
-        {
-            if (_mediaType == null || _content == null)
-                return "no";
-
-            return _mediaType.ToLowerInvariant() switch
-            {
-                MediaTypeNames.Application.Json => $"'{JsonSerializer.Serialize(_content, JsonWriteFormat.None)}' [{_mediaType}]",
-                _ => $"'{_content}' [{_mediaType}]",
-            };
         }
 
         /// <summary>

--- a/src/UnitTestEx/Mocking/MockHttpClientResponse.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientResponse.cs
@@ -167,7 +167,10 @@ namespace UnitTestEx.Mocking
             ResponseAction = response;
 
             if (_rule != null)
+            {
+                _rule.Responses = null;
                 _clientRequest.MockResponse();
+            }
         }
 
         /// <summary>
@@ -250,6 +253,7 @@ namespace UnitTestEx.Mocking
 
             ArgumentNullException.ThrowIfNull(sequence);
 
+            _rule.Response = null;
             _rule.Responses ??= [];
 
             var s = new MockHttpClientResponseSequence(_clientRequest, _rule);


### PR DESCRIPTION
- *Fixed:* The `MockHttpClientRequest` now resets the internal count state when overridding a response to ensure `Verify()` functions correctly.