### PR TITLE
v5.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 Represents the **NuGet** versions.
 
+## v5.10.0
+- *Enhancement:* `TestSharedState` updated to enable request-based (isolated) state; with the corresponding `GetHttpRequestId()` method now made public.
+- *Enhancement:* Added `ApiTesterBase.AddPreRunAction()`, `AddPostRunBeforeExpectationsAction()`, `AddPostRunAfterExpectationsAction()` and `AddPostRunAction()` to enable the addition of actions to be executed at different stages of the `Run`/`RunAsync` process for every underlying test. This will enable the addition of common pre/post processing logic without having to explicitly add to each test.
+- *Enhancement:* `TEntryPoint` methods can now be specified as `static`.  
+- *Enhancement:* `ApiError` added implicit conversion from (`string?`, `string`) tuple to enable simplified usage; e.g. `AssertErrors(("field", "Bad Request"))` versus `AssertErrors(new ApiError("field", "Bad Request"))`.
+- *Fixed:* Reset `MockHttpClientRequest` internal state when using any `With*` method to ensure correct behavior.
+
 ## v5.9.2
-- *Fixed:* The `MockHttpClientRequest` now resets the internal count state when overridding a response to ensure `Verify()` functions correctly.
+- *Fixed:* The `MockHttpClientRequest` now resets the internal count state when overriding a response to ensure `Verify()` functions correctly.
 
 ## v5.9.1
 - *Fixed:* The `MockHttpClientRequest` now caches the response content internally, and creates a new `HttpContent` instance for each request to ensure that the content can be read multiple times across multiple requests (where applicable); avoids potential object disposed error.
@@ -95,10 +102,10 @@ Represents the **NuGet** versions.
   - `CreateFunctionTester<TStartup>()` replaced with `FunctionTester.Create<TStartup>()`.
 
 ## v4.4.2
-- *Fixed*: Updated `System.Text.Json` package depenedency to latest; resolve [Microsoft Security Advisory CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).
+- *Fixed*: Updated `System.Text.Json` package dependency to latest; resolve [Microsoft Security Advisory CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).
 
 ## v4.4.1
-- *Fixed:* Updated all package depenedencies to latest.
+- *Fixed:* Updated all package dependencies to latest.
 
 ## v4.4.0
 - *Enhancement:* Added `ExpectJson` and `ExpectJsonFromResource` to `IValueExpectations` to enable value comparison against the specified (expected) JSON.
@@ -136,7 +143,7 @@ Represents the **NuGet** versions.
 - *Fixed:* Removed all dependencies to `Newtonsoft.Json`; a developer will need to explicitly add this dependency and `IJsonSerializer` implementation where applicable.
 
 ## v4.0.0
-All internal dependecies to `CoreEx` have been removed. This is intended to further generalize the capabilities of `UnitTestEx`; but more importantly, break the circular dependency reference between the two repositories. New `CoreEx.UnitTesting*` packages have been created to extend the `UnitTestEx` capabilities for `CoreEx`.
+All internal dependencies to `CoreEx` have been removed. This is intended to further generalize the capabilities of `UnitTestEx`; but more importantly, break the circular dependency reference between the two repositories. New `CoreEx.UnitTesting*` packages have been created to extend the `UnitTestEx` capabilities for `CoreEx`.
  - *Enhancement:* All typed value assertions have been named `AssertValue` for consistency; otherwise, `AssertContent` for a simple string comparison.
  - *Enhancement:* All JSON-related assertions have been named `AssertJson*` for consistency.
  - *Enhancement:* The `CreateServiceBusMessage` methods that accept a generic `T` value have been renamed to `CreateServiceBusMessageFromValue`.
@@ -149,7 +156,7 @@ All internal dependecies to `CoreEx` have been removed. This is intended to furt
 The enhancements have been made in a manner to maximize backwards compatibility with previous versions of `UnitTestEx` where possible; however, some breaking changes were unfortunately unavoidable (and made to improve overall). There may be an opportunity for the consuming developer to add extension methods to support the previous naming conventions if desired; note that the next `CoreEx` version (`v3.6.0`) will implement extensions in new `CoreEx.UnitTesting` packages to support existing behaviors (where applicable).
 
 ## v3.1.0
-- *Enhancement:* Updated all package depenedencies to latest.
+- *Enhancement:* Updated all package dependencies to latest.
 - *Enhancement:* The `GenericTester` updated to support `IHostStartup` to enable shared host dependency injection configuration.
 - *Enhancement:* Added `IEventExpectations<TSelf>` and `ILoggerExpectations<TSelf>` support to `GenericTester` and `ValidationTester`.
 - *Enhancement:* Moved the `CreateServiceBusMessage` and related methods from `FunctionTesterBase` up the inheritance hierarchy to `TesterBase<TSelf>` to enable broader usage.
@@ -193,7 +200,7 @@ The enhancements have been made in a manner to maximize backwards compatibility 
 - *Fixed:* Incorrect package deployment; corrected.
 
 ## v2.1.0
-- *Enhancement:* Added `TestSetUp.RegisterAutoSetUp` that will automatically throw a `TestSetUpException` where unsuccessful; otherwise, queues the successful output message. This is required as most testing frameworks do not allow for a log write during construction or fuxture set up. The underlying _UnitTestEx_ test classes will automatically log write where entries are discovered in the queue. This will at least ensure one of the underlying tests will output the success output where applicable. Otherwise, to log write explicitly use `TestSetUp.LogAutoSetUpOutputs`.
+- *Enhancement:* Added `TestSetUp.RegisterAutoSetUp` that will automatically throw a `TestSetUpException` where unsuccessful; otherwise, queues the successful output message. This is required as most testing frameworks do not allow for a log write during construction or fixture set up. The underlying _UnitTestEx_ test classes will automatically log write where entries are discovered in the queue. This will at least ensure one of the underlying tests will output the success output where applicable. Otherwise, to log write explicitly use `TestSetUp.LogAutoSetUpOutputs`.
 
 ## v2.0.0
 - *Enhancement:* Updated `CoreEx` dependencies to `2.0.0` as breaking changes were introduced. There are no breaking changes within `UnitTestEx` as a result; primarily related to the key `CoreEx` dependency.
@@ -224,7 +231,7 @@ The enhancements have been made in a manner to maximize backwards compatibility 
 - *Fixed:* Handle `AggregateException` by using its `InnerException` as the `Exception`.
 
 ## v1.0.24
-- *Enhancement:* Updated the `ControllerTester` removing the HTTP request capabilies and moving into new `HttpTester`; this creates a more logical split as the latter needs no knowledge of the `Controller`. This new tester is available via `ApiTester.Http().Run(...)`.
+- *Enhancement:* Updated the `ControllerTester` removing the HTTP request capabilities and moving into new `HttpTester`; this creates a more logical split as the latter needs no knowledge of the `Controller`. This new tester is available via `ApiTester.Http().Run(...)`.
 - *Enhancement:* Added new `UnitTextEx.Expectations` namespace; when added will enable `Expect*` and `Ignore*` pre-execution assertions, that are then executed post `Run`/`RunAsync`. Some testers now also support the specification of a `TResponse` generic `Type` to enable further response value-related expectations.
 
 ## v1.0.23
@@ -283,7 +290,7 @@ The enhancements have been made in a manner to maximize backwards compatibility 
 - *Enhancement:* **Breaking change.** Integrate [`CoreEx`](https://github.com/Avanade/CoreEx/) package which primarily brings [`IJsonSerializer`](https://github.com/Avanade/CoreEx/blob/main/src/CoreEx/Json/IJsonSerializer.cs) functionality to enable configuration of either [`CoreEx.Text.Json.JsonSerializer`](https://github.com/Avanade/CoreEx/blob/main/src/CoreEx/Text/Json/JsonSerializer.cs) (default) or [`CoreEx.Newtonsoft.Json.JsonSerializer`](https://github.com/Avanade/CoreEx/blob/main/src/CoreEx.Newtonsoft/Json/JsonSerializer.cs). The `MockHttpClientFactory`, `ApiTester` and `FunctionTester` have new method `UseJsonSerializer` to individually update from the default. To change the default for all tests then set [`CoreEx.Json.JsonSerializer.Default`](https://github.com/Avanade/CoreEx/blob/main/src/CoreEx/Json/JsonSerializer.cs) to the desired serializer.
 - *Enhancement:* Improved the replacement of the `MockHttpClientFactory` with the `ApiTester` and `FunctionTester`. Existing code `test.ConfigureServices(sc => mcf.Replace(sc))` can be replaced with `test.ReplaceHttpClientFactory(mcf)`.
 - *Enhancement:* Added `ReplaceSingleton`, `ReplaceScoped` and `ReplaceTransient` methods directly to `ApiTester` and `FunctionTester`. For example, existing code `test.ConfigureServices(sc => sc.ReplaceTransient<XXX>())` can be replaced with `test.ReplaceTransient<XXX>()`.
-- *Enhancement:* Added addtional `CreateHttpRequest` overloads to support additional parameters `HttpRequestOptions? requestOptions = null, params IHttpArg[] args` as enabled by `CoreEx`. These enable additional capabilities for the `HttpRequest` query string and headers.
+- *Enhancement:* Added additional `CreateHttpRequest` overloads to support additional parameters `HttpRequestOptions? requestOptions = null, params IHttpArg[] args` as enabled by `CoreEx`. These enable additional capabilities for the `HttpRequest` query string and headers.
 
 ## v1.0.11
 - *[Issue 24](https://github.com/Avanade/UnitTestEx/issues/24)*: Added additional `IServiceCollection.Replace` extension methods to support `ReplaceXxx<T>()` and `ReplaceXxx<T, T>()` to match the standard `AddXxx` methods.
@@ -319,10 +326,10 @@ The enhancements have been made in a manner to maximize backwards compatibility 
 ## v1.0.4
 - *[Issue 3](https://github.com/Avanade/UnitTestEx/issues/3)*: Added support for MOQ `Times` struct to verify the number of times a request is made.
 - *[Issue 4](https://github.com/Avanade/UnitTestEx/issues/4)*: Added support for MOQ sequences; i.e. multiple different responses.
-- *[Issue 5](https://github.com/Avanade/UnitTestEx/issues/5)*: Deleted `MockServiceBus` as the mocking failed to work as intended. This has been replaced by `FunctionTesterBase` methods of `CreateServiceBusMessage`, `CreateServiceBusMessageFromResource` and `CreateServiceBusMessageFromJson`.
+- *[Issue 5](https://github.com/Avanade/UnitTestEx/issues/5)*: Delete `MockServiceBus` as the mocking failed to work as intended. This has been replaced by `FunctionTesterBase` methods of `CreateServiceBusMessage`, `CreateServiceBusMessageFromResource` and `CreateServiceBusMessageFromJson`.
 
 ## v1.0.3
-- *Fixed:* `MockHttpClientFactory.CreateClient` overloads were ambiquous, this has been corrected.
+- *Fixed:* `MockHttpClientFactory.CreateClient` overloads were ambiguous, this has been corrected.
 - *Fixed:* Resolved logging output challenges between the various test frameworks and `ApiTester` (specifically) to achieve consistent output.
 - *Enhancement:* The logging output now includes scope details.
 - *Added:* New `MockServiceBus.CreateReceivedMessage` which will mock the `ServiceBusReceivedMessage` and add the passed value as serialized JSON into the `Body` (`BinaryData`).

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.9.2</Version>
+		<Version>5.10.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx.Azure.ServiceBus/ExtensionMethods.cs
+++ b/src/UnitTestEx.Azure.ServiceBus/ExtensionMethods.cs
@@ -41,7 +41,7 @@ namespace UnitTestEx
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer <see cref="Type.Assembly"/> for the embedded resources.</typeparam>
         /// <param name="tester">The <see cref="TesterBase"/>.</param>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
         /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
         public static ServiceBusReceivedMessage CreateServiceBusMessageFromResource<TAssembly>(this TesterBase tester, string resourceName, Action<AmqpAnnotatedMessage>? messageModify = null)
@@ -51,7 +51,7 @@ namespace UnitTestEx
         /// Creates a <see cref="ServiceBusReceivedMessage"/> where the <see cref="ServiceBusMessage.Body"/> <see cref="BinaryData"/> will contain the JSON formatted embedded resource as the content (<see cref="MediaTypeNames.Application.Json"/>).
         /// </summary>
         /// <param name="tester">The <see cref="TesterBase"/>.</param>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetEntryAssembly()"/>.</param>
         /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>

--- a/src/UnitTestEx/Abstractions/TestSharedState.cs
+++ b/src/UnitTestEx/Abstractions/TestSharedState.cs
@@ -13,6 +13,9 @@ namespace UnitTestEx.Abstractions
     /// <summary>
     /// Provides a means to share state between the <see cref="TesterBase"/> and the corresponding execution.
     /// </summary>
+    /// <remarks>The <see cref="GetHttpRequestId"/>-based functionality is primarily intended for use with <see cref="AspNetCore.HttpTesterBase"/> and related HTTP testing; however, it is available for any
+    /// testing where sharing state between the tester and execution is required.
+    /// <para>Be careful when using this class that data does not cross boundaries where it is scoped, or may be disposed, as this may result in unintended side-effect/consequences.</para></remarks>
     public sealed class TestSharedState
     {
 #if NET9_0_OR_GREATER
@@ -38,7 +41,7 @@ namespace UnitTestEx.Abstractions
         /// <param name="message">The log message.</param>
         public void AddLoggerMessage(string? message)
         {
-            var id = GetRequestId();
+            var id = GetHttpRequestId();
 
             lock (_lock)
             {
@@ -54,9 +57,11 @@ namespace UnitTestEx.Abstractions
         }
 
         /// <summary>
-        /// Gets the correlation identifier.
+        /// Gets the HTTP request correlation identifier.
         /// </summary>
-        private string GetRequestId()
+        /// <remarks>This identifier is used to correlate log messages and other state information with a specific HTTP request.
+        /// <para>This is only meaningful within the context of an executing host.</para></remarks>
+        public string GetHttpRequestId()
         {
             if (HttpContextAccessor == null || HttpContextAccessor.HttpContext == null)
                 return string.Empty;
@@ -93,6 +98,29 @@ namespace UnitTestEx.Abstractions
         /// Gets the state extension data that can be used for additional state information (where applicable).
         /// </summary>
         public ConcurrentDictionary<string, object?> StateData { get; } = new ConcurrentDictionary<string, object?>();
+
+        /// <summary>
+        /// Gets the state extension data for the specified <paramref name="requestId"/> that can be used for additional state information (where applicable).
+        /// </summary>
+        /// <param name="requestId">The unit testing request identifier.</param>
+        /// <returns>The state extension data for the specified <paramref name="requestId"/>.</returns>
+        /// <remarks>A <paramref name="requestId"/> that is <see cref="String.IsNullOrEmpty(string?)"/> will return the <see cref="StateData"/>; i.e. is assumed not to be request-based.</remarks>
+        public ConcurrentDictionary<string, object?> RequestStateData(string? requestId)
+            => string.IsNullOrEmpty(requestId)
+                ? StateData
+                : StateData.GetOrAdd(requestId, _ => new ConcurrentDictionary<string, object?>()) as ConcurrentDictionary<string, object?> ?? new ConcurrentDictionary<string, object?>();
+
+        /// <summary>
+        /// Removes the state data associated with the specified <paramref name="requestId"/>, if it exists.
+        /// </summary>
+        /// <param name="requestId">The unit testing request identifier.</param>
+        public void RemoveRequestStateData(string? requestId)
+        {
+            if (string.IsNullOrEmpty(requestId))
+                return;
+
+            StateData.TryRemove(requestId, out _);
+        }
 
         /// <summary>
         /// Resets the <see cref="TestSharedState"/>.

--- a/src/UnitTestEx/Abstractions/TesterBase.cs
+++ b/src/UnitTestEx/Abstractions/TesterBase.cs
@@ -15,7 +15,6 @@ using System.Net.Mime;
 using System.Reflection;
 using System.Text;
 using System.Threading;
-using UnitTestEx.AspNetCore;
 using UnitTestEx.Expectations;
 using UnitTestEx.Json;
 using UnitTestEx.Logging;

--- a/src/UnitTestEx/Abstractions/TesterBase.cs
+++ b/src/UnitTestEx/Abstractions/TesterBase.cs
@@ -15,6 +15,8 @@ using System.Net.Mime;
 using System.Reflection;
 using System.Text;
 using System.Threading;
+using UnitTestEx.AspNetCore;
+using UnitTestEx.Expectations;
 using UnitTestEx.Json;
 using UnitTestEx.Logging;
 
@@ -190,7 +192,7 @@ namespace UnitTestEx.Abstractions
         /// <summary>
         /// Enables opportunity to execute logic immediately after the underlying host has been started. 
         /// </summary>
-        /// <remarks>Where overridding ensure the base is invoked first to avoid unintended side-effects as <see cref="TesterBase"/> will invoke the registered <see cref="OnHostStart(Action, bool)"/>.
+        /// <remarks>Where overriding ensure the base is invoked first to avoid unintended side-effects as <see cref="TesterBase"/> will invoke the registered <see cref="OnHostStart(Action, bool)"/>.
         /// <para><i>Note:</i> a host lifetime can span one or more tests so this should not be used for per-test set-up/configuration. Equally, a <see cref="ResetHost()"/> will result in a new host instantiation on first access.</para></remarks>
         protected virtual void OnHostStartUp()
         {
@@ -254,6 +256,66 @@ namespace UnitTestEx.Abstractions
         }
 
         /// <summary>
+        /// Gets the list of pre-run actions to be executed before the underlying test <b>Run</b> occurs.
+        /// </summary>
+        protected List<Action<IExpectations>> PreRunActions { get; } = [];
+
+        /// <summary>
+        /// Gets the list of post-run actions to be executed after the underlying test <b>Run</b> occurs (before <see cref="Expectations.ExpectationsArranger{TTester}.AssertAsync(Expectations.AssertArgs)"/>).
+        /// </summary>
+        protected List<Action<IExpectations>> PostRunBeforeExpectationsActions { get; } = [];
+
+        /// <summary>
+        /// Gets the list of post-run actions to be executed after the underlying test <b>Run</b> occurs (after <see cref="Expectations.ExpectationsArranger{TTester}.AssertAsync(Expectations.AssertArgs)"/>).
+        /// </summary>
+        protected List<Action<IExpectations>> PostRunAfterExpectationsActions { get; } = [];
+
+        /// <summary>
+        /// Gets the list of post-run actions to be executed after the underlying test <b>Run</b> occurs (always executed regardless of result to enable the likes of clean-up etc.).
+        /// </summary>
+        protected List<Action<IExpectations>> PostRunActions { get; } = [];
+
+        /// <summary>
+        /// Executes the pre-run actions before the underlying test <b>Run</b> occurs.
+        /// </summary>
+        /// <param name="tester">The <see cref="IExpectations"/> tester instance.</param>
+        internal void ExecutePreRunActions(IExpectations tester)
+        {
+            foreach (var action in PreRunActions)
+                action(tester);
+        }
+
+        /// <summary>
+        /// Executes the post-run actions after the underlying test <b>Run</b> occurs (before <see cref="Expectations.ExpectationsArranger{TTester}.AssertAsync(Expectations.AssertArgs)"/>).
+        /// </summary>
+        /// <param name="tester">The <see cref="IExpectations"/> tester instance.</param>
+        internal void ExecutePostRunBeforeExpectationsActions(IExpectations tester)
+        {
+            foreach (var action in PostRunBeforeExpectationsActions)
+                action(tester);
+        }
+
+        /// <summary>
+        /// Executes the post-run actions after the underlying test <b>Run</b> occurs (before <see cref="Expectations.ExpectationsArranger{TTester}.AssertAsync(Expectations.AssertArgs)"/>).
+        /// </summary>
+        /// <param name="tester">The <see cref="IExpectations"/> tester instance.</param>
+        internal void ExecutePostRunAfterExpectationsActions(IExpectations tester)
+        {
+            foreach (var action in PostRunAfterExpectationsActions)
+                action(tester);
+        }
+
+        /// <summary>
+        /// Executes the post-run actions after the underlying test <b>Run</b> occurs (always executed regardless of result to enable the likes of clean-up etc.).
+        /// </summary>
+        /// <param name="tester">The <see cref="IExpectations"/> tester instance.</param>
+        internal void ExecutePostRunActions(IExpectations tester)
+        {
+            foreach (var action in PostRunActions)
+                action(tester);
+        }
+
+        /// <summary>
         /// Replaces the <see cref="TestFrameworkImplementor"/> with the specified <paramref name="implementor"/>.
         /// </summary>
         /// <param name="implementor">The new <see cref="TestFrameworkImplementor"/>.</param>
@@ -311,7 +373,7 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> with no body.
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
+        /// <param name="requestUri">The request uri.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
 #if NET7_0_OR_GREATER
         public HttpRequest CreateHttpRequest(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri)
@@ -324,7 +386,7 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> with <paramref name="body"/> (defaults <see cref="HttpRequest.ContentType"/> to <see cref="MediaTypeNames.Text.Plain"/>).
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
+        /// <param name="requestUri">The request uri.</param>
         /// <param name="body">The optional body content.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
 #if NET7_0_OR_GREATER
@@ -338,7 +400,7 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> with <paramref name="body"/> and <paramref name="contentType"/>.
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
+        /// <param name="requestUri">The request uri.</param>
         /// <param name="body">The optional body content.</param>
         /// <param name="contentType">The content type. Defaults to <see cref="MediaTypeNames.Text.Plain"/>.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
@@ -353,7 +415,7 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> with no body.
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
+        /// <param name="requestUri">The request uri.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequest"/> modifier.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
 #if NET7_0_OR_GREATER
@@ -367,7 +429,7 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> with <paramref name="body"/> (defaults <see cref="HttpRequest.ContentType"/> to <see cref="MediaTypeNames.Text.Plain"/>).
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
+        /// <param name="requestUri">The request uri.</param>
         /// <param name="body">The optional body content.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequest"/> modifier.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
@@ -382,7 +444,7 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> with <i>optional</i> <paramref name="body"/> (defaults <see cref="HttpRequest.ContentType"/> to <see cref="MediaTypeNames.Text.Plain"/>).
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
+        /// <param name="requestUri">The request uri.</param>
         /// <param name="body">The optional body content.</param>
         /// <param name="contentType">The content type. Defaults to <see cref="MediaTypeNames.Text.Plain"/>.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequest"/> modifier.</param>
@@ -432,7 +494,7 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> with the <paramref name="value"/> JSON serialized as <see cref="HttpRequest.ContentType"/> of <see cref="MediaTypeNames.Application.Json"/>.
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
+        /// <param name="requestUri">The request uri.</param>
         /// <param name="value">The value to JSON serialize.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
 #if NET7_0_OR_GREATER
@@ -446,7 +508,7 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> with the <paramref name="value"/> JSON serialized as <see cref="HttpRequest.ContentType"/> of <see cref="MediaTypeNames.Application.Json"/>.
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
+        /// <param name="requestUri">The request uri.</param>
         /// <param name="value">The value to JSON serialize.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequest"/> modifier.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
@@ -462,8 +524,8 @@ namespace UnitTestEx.Abstractions
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer <see cref="Type.Assembly"/> for the embedded resources.</typeparam>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="requestUri">The request uri.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
 #if NET7_0_OR_GREATER
         public HttpRequest CreateJsonHttpRequestFromResource<TAssembly>(HttpMethod httpMethod, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, string resourceName)
@@ -477,8 +539,8 @@ namespace UnitTestEx.Abstractions
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer <see cref="Type.Assembly"/> for the embedded resources.</typeparam>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="requestUri">The request uri.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequest"/> modifier.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
 #if NET7_0_OR_GREATER
@@ -492,8 +554,8 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> using the JSON formatted embedded resource as the content (<see cref="MediaTypeNames.Application.Json"/>).
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="requestUri">The request uri.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetEntryAssembly()"/>.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>
 #if NET7_0_OR_GREATER
@@ -507,8 +569,8 @@ namespace UnitTestEx.Abstractions
         /// Creates a new <see cref="HttpRequest"/> using the JSON formatted embedded resource as the content (<see cref="MediaTypeNames.Application.Json"/>).
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod"/>.</param>
-        /// <param name="requestUri">The requuest uri.</param>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="requestUri">The request uri.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetEntryAssembly()"/>.</param>
         /// <param name="requestModifier">The optional <see cref="HttpRequest"/> modifier.</param>
         /// <returns>The <see cref="HttpRequest"/>.</returns>

--- a/src/UnitTestEx/ApiError.cs
+++ b/src/UnitTestEx/ApiError.cs
@@ -18,5 +18,17 @@ namespace UnitTestEx
         /// Gets the error message.
         /// </summary>
         public string Message { get; } = message;
+
+        /// <summary>
+        /// Implicitly converts a <c>(string? field, string message)</c> tuple to an <see cref="ApiError"/>.
+        /// </summary>
+        /// <param name="error">The tuple containing the field and message.</param>
+        public static implicit operator ApiError((string? field, string message) error) => new(error.field, error.message);
+
+        /// <summary>
+        /// Implicitly converts a <paramref name="message"/> <see cref="string"/> to an <see cref="ApiError"/>.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        public static implicit operator ApiError(string message) => new(null, message);
     }
 }

--- a/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/ApiTesterBase.cs
@@ -10,10 +10,12 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnitTestEx.Abstractions;
+using UnitTestEx.Expectations;
 
 namespace UnitTestEx.AspNetCore
 {
@@ -178,6 +180,58 @@ namespace UnitTestEx.AspNetCore
                 throw new InvalidOperationException("The content root must be set before the WebApplicationFactory is instantiated.");
 
             _solutionRelativePath = solutionRelativePath;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Adds an action to be executed before the underlying test <b>Run</b> occurs.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf AddPreRunAction(Action<IExpectations> action)
+        {
+            if (action is not null)
+                PreRunActions.Add(tester => action(tester));
+
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Adds an action to be to be executed after the underlying test <b>Run</b> occurs (before <see cref="Expectations.ExpectationsArranger{TTester}.AssertAsync(Expectations.AssertArgs)"/>).
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf AddPostRunBeforeExpectationsAction(Action<IExpectations> action)
+        {
+            if (action is not null)
+                PostRunBeforeExpectationsActions.Add(tester => action(tester));
+
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Adds an action to be to be executed after the underlying test <b>Run</b> occurs (after <see cref="Expectations.ExpectationsArranger{TTester}.AssertAsync(Expectations.AssertArgs)"/>).
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf AddPostRunAfterExpectationsAction(Action<IExpectations> action)
+        {
+            if (action is not null)
+                PostRunAfterExpectationsActions.Add(tester => action(tester));
+
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Adds an action to be executed after the underlying test <b>Run</b> occurs (after all other post-run actions regardless of result).
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf AddPostRunAction(Action<IExpectations> action)
+        {
+            if (action is not null)
+                PostRunActions.Add(tester => action(tester));
+
             return (TSelf)this;
         }
 

--- a/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
@@ -175,7 +175,7 @@ namespace UnitTestEx.AspNetCore
             }
             finally
             {
-                Owner.ExecutePreRunActions(this);
+                Owner.ExecutePostRunActions(this);
                 Owner.SharedState.RemoveRequestStateData(RequestId);
             }
         }

--- a/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using UnitTestEx.Abstractions;
 using UnitTestEx.Assertors;
+using UnitTestEx.Expectations;
 using UnitTestEx.Json;
 using UnitTestEx.Mocking;
 
@@ -22,7 +23,7 @@ namespace UnitTestEx.AspNetCore
     /// <summary>
     /// Provides the base HTTP testing capabilities.
     /// </summary>
-    public abstract class HttpTesterBase
+    public abstract class HttpTesterBase : IExpectations
     {
         /// <summary>
         /// Gets the '<c>unit-test-ex-request-id</c>' constant.
@@ -67,7 +68,7 @@ namespace UnitTestEx.AspNetCore
         public string? UserName { get; protected set; }
 
         /// <summary>
-        /// Gets the unqiue request identifier.
+        /// Gets the unique request identifier.
         /// </summary>
         /// <remarks>This value is related to the <see cref="RequestIdName"/>.</remarks>
         public string RequestId { get; } = Guid.NewGuid().ToString();
@@ -90,11 +91,22 @@ namespace UnitTestEx.AspNetCore
         protected async Task<HttpResponseMessageAssertor> SendAsync(HttpMethod httpMethod, string? requestUri, Action<HttpRequestMessage>? requestModifier)
 #endif
         {
-            using var client = CreateHttpClient();
-            var res = await new TypedHttpClient(client, JsonSerializer).SendAsync(httpMethod, requestUri, requestModifier).ConfigureAwait(false);
-            await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
-            await AssertExpectationsAsync(res).ConfigureAwait(false);
-            return new HttpResponseMessageAssertor(Owner, res);
+            try
+            {
+                Owner.ExecutePreRunActions(this);
+                using var client = CreateHttpClient();
+                var res = await new TypedHttpClient(client, JsonSerializer).SendAsync(httpMethod, requestUri, requestModifier).ConfigureAwait(false);
+                await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
+                Owner.ExecutePostRunBeforeExpectationsActions(this);
+                await AssertExpectationsAsync(res).ConfigureAwait(false);
+                Owner.ExecutePostRunAfterExpectationsActions(this);
+                return new HttpResponseMessageAssertor(Owner, res);
+            }
+            finally
+            {
+                Owner.ExecutePostRunActions(this);
+                Owner.SharedState.RemoveRequestStateData(RequestId);
+            }
         }
 
         /// <summary>
@@ -112,14 +124,25 @@ namespace UnitTestEx.AspNetCore
         protected async Task<HttpResponseMessageAssertor> SendAsync(HttpMethod httpMethod, string? requestUri, string? content, string? contentType, Action<HttpRequestMessage>? requestModifier)
 #endif
         {
-            if (content != null && httpMethod == HttpMethod.Get)
-                Owner.LoggerProvider.CreateLogger("ApiTester").LogWarning("A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request (see https://www.rfc-editor.org/rfc/rfc7231).");
+            try
+            {
+                Owner.ExecutePreRunActions(this);
+                if (content != null && httpMethod == HttpMethod.Get)
+                    Owner.LoggerProvider.CreateLogger("ApiTester").LogWarning("A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request (see https://www.rfc-editor.org/rfc/rfc7231).");
 
-            using var client = CreateHttpClient();
-            var res = await new TypedHttpClient(client, JsonSerializer).SendAsync(httpMethod, requestUri, content, contentType, requestModifier).ConfigureAwait(false);
-            await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
-            await AssertExpectationsAsync(res).ConfigureAwait(false);
-            return new HttpResponseMessageAssertor(Owner, res);
+                using var client = CreateHttpClient();
+                var res = await new TypedHttpClient(client, JsonSerializer).SendAsync(httpMethod, requestUri, content, contentType, requestModifier).ConfigureAwait(false);
+                await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
+                Owner.ExecutePostRunBeforeExpectationsActions(this);
+                await AssertExpectationsAsync(res).ConfigureAwait(false);
+                Owner.ExecutePostRunAfterExpectationsActions(this);
+                return new HttpResponseMessageAssertor(Owner, res);
+            }
+            finally
+            {
+                Owner.ExecutePostRunActions(this);
+                Owner.SharedState.RemoveRequestStateData(RequestId);
+            }
         }
 
         /// <summary>
@@ -136,14 +159,25 @@ namespace UnitTestEx.AspNetCore
         protected async Task<HttpResponseMessageAssertor> SendAsync(HttpMethod httpMethod, string? requestUri, object? value, Action<HttpRequestMessage>? requestModifier)
 #endif
         {
-            if (value != null && httpMethod == HttpMethod.Get)
-                Owner.LoggerProvider.CreateLogger("ApiTester").LogWarning("A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request (see https://www.rfc-editor.org/rfc/rfc7231).");
+            try
+            {
+                Owner.ExecutePreRunActions(this);
+                if (value != null && httpMethod == HttpMethod.Get)
+                    Owner.LoggerProvider.CreateLogger("ApiTester").LogWarning("A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request (see https://www.rfc-editor.org/rfc/rfc7231).");
 
-            using var client = CreateHttpClient();
-            var res = await new TypedHttpClient(client, JsonSerializer).SendAsync(httpMethod, requestUri, value, requestModifier).ConfigureAwait(false);
-            await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
-            await AssertExpectationsAsync(res).ConfigureAwait(false);
-            return new HttpResponseMessageAssertor(Owner, res);
+                using var client = CreateHttpClient();
+                var res = await new TypedHttpClient(client, JsonSerializer).SendAsync(httpMethod, requestUri, value, requestModifier).ConfigureAwait(false);
+                await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
+                Owner.ExecutePostRunBeforeExpectationsActions(this);
+                await AssertExpectationsAsync(res).ConfigureAwait(false);
+                Owner.ExecutePostRunAfterExpectationsActions(this);
+                return new HttpResponseMessageAssertor(Owner, res);
+            }
+            finally
+            {
+                Owner.ExecutePreRunActions(this);
+                Owner.SharedState.RemoveRequestStateData(RequestId);
+            }
         }
 
         /// <summary>

--- a/src/UnitTestEx/Assertors/ActionResultAssertor.cs
+++ b/src/UnitTestEx/Assertors/ActionResultAssertor.cs
@@ -118,7 +118,7 @@ namespace UnitTestEx.Assertors
         /// Asserts that the <see cref="Result"/> has the specified <c>Content</c> matches the JSON serialized value.
         /// </summary>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected value as serialized JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
         public ActionResultAssertor AssertValueFromJsonResource<TValue>(string resourceName, params string[] pathsToIgnore)
@@ -129,7 +129,7 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected value as serialized JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
         public ActionResultAssertor AssertValueFromJsonResource<TAssembly, TValue>(string resourceName, params string[] pathsToIgnore) 
@@ -362,7 +362,7 @@ namespace UnitTestEx.Assertors
         /// <summary>
         /// Asserts that the <see cref="Result"/> has the specified <c>Content</c> matches the JSON value.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
         public ActionResultAssertor AssertJsonFromResource(string resourceName, params string[] pathsToIgnore)

--- a/src/UnitTestEx/Assertors/Assertor.cs
+++ b/src/UnitTestEx/Assertors/Assertor.cs
@@ -36,7 +36,7 @@ namespace UnitTestEx.Assertors
         }
 
         /// <summary>
-        /// Trys to match the <paramref name="expected"/> and <paramref name="actual"/> <see cref="ApiError"/> contents.
+        /// Tries to match the <paramref name="expected"/> and <paramref name="actual"/> <see cref="ApiError"/> contents.
         /// </summary>
         /// <param name="expected">The expected <see cref="ApiError"/> list.</param>
         /// <param name="actual">The actual <see cref="ApiError"/> list.</param>
@@ -56,13 +56,32 @@ namespace UnitTestEx.Assertors
             if (exp.Count > 0)
             {
                 sb.AppendLine(" Expected messages not matched:");
-                exp.ForEach(m => sb.AppendLine($" Error: {m.Message} {(m.Field != null ? $"[{m.Field}]" : null)}"));
+                exp.ForEach(m => sb.AppendLine($"  > {(m.Field != null ? $"{m.Field}" : "null")}: {m.Message}"));
             }
 
             if (act.Count > 0)
             {
+                if (exp.Count > 0)
+                    sb.AppendLine();
+
                 sb.AppendLine(" Actual messages not matched:");
-                act.ForEach(m => sb.AppendLine($" Error: {m.Message} {(m.Field != null ? $"[{m.Field}]" : null)}"));
+                act.ForEach(m => sb.AppendLine($"  > {(m.Field != null ? $"{m.Field}" : "null")}: {m.Message}"));
+            }
+
+            if (act.Count > 0)
+            {
+                sb.AppendLine().AppendLine();
+                sb.AppendLine("All actual message tuples as follows:");
+
+                for (int i = 0; i < act.Count; i++)
+                {
+                    var m = act[i];
+                    sb.Append($"  ({(m.Field != null ? $"\"{m.Field}\"" : "null")}, \"{m.Message}\")");
+                    if (i < act.Count - 1)
+                        sb.AppendLine(",");
+                    else
+                        sb.AppendLine();
+                }
             }
 
             errorMessage = sb.Length > 0 ? $"Error messages mismatch:{System.Environment.NewLine}{sb}" : null;

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBase.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBase.cs
@@ -9,7 +9,7 @@ using UnitTestEx.Json;
 namespace UnitTestEx.Assertors
 {
     /// <summary>
-    /// Provdes the base <see cref="HttpResponseMessage"/> test assert helper capabilities.
+    /// Provides the base <see cref="HttpResponseMessage"/> test assert helper capabilities.
     /// </summary>
     /// <remarks>
     /// Initializes a new instance of the <see cref="HttpResponseMessageAssertorBase{TSelf}"/> class.

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
@@ -14,7 +14,7 @@ using UnitTestEx.Abstractions;
 namespace UnitTestEx.Assertors
 {
     /// <summary>
-    /// Provdes the base <see cref="HttpResponseMessage"/> test assert helper capabilities.
+    /// Provides the base <see cref="HttpResponseMessage"/> test assert helper capabilities.
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
     /// <param name="response">The <see cref="HttpResponseMessage"/>.</param>
@@ -256,7 +256,7 @@ namespace UnitTestEx.Assertors
         /// <summary>
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> JSON content matches the JSON from the embedded resource.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertorBase{TSelf}"/> instance to support fluent-style method-chaining.</returns>
         public TSelf AssertJsonFromResource(string resourceName, params string[] pathsToIgnore) => AssertJson(Resource.GetJson(resourceName, Assembly.GetCallingAssembly()), pathsToIgnore);
@@ -265,7 +265,7 @@ namespace UnitTestEx.Assertors
         /// Asserts that the <see cref="HttpResponseMessageAssertorBase.Response"/> matches the JSON serialized value.
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected value as serialized JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="HttpResponseMessageAssertorBase{TSelf}"/> instance to support fluent-style method-chaining.</returns>
         public TSelf AssertJsonFromResource<TAssembly>(string resourceName, params string[] pathsToIgnore) => AssertJson(Resource.GetJson(resourceName, typeof(TAssembly).Assembly), pathsToIgnore);

--- a/src/UnitTestEx/Assertors/ValueAssertor.cs
+++ b/src/UnitTestEx/Assertors/ValueAssertor.cs
@@ -69,7 +69,7 @@ namespace UnitTestEx.Assertors
         /// <summary>
         /// Asserts that the <see cref="Value"/> matches the JSON serialized value from the named embedded resource.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected value as serialized JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
         public ValueAssertor<TValue> AssertJsonFromResource(string resourceName, params string[] pathsToIgnore)
@@ -79,7 +79,7 @@ namespace UnitTestEx.Assertors
         /// Asserts that the <see cref="Value"/> matches the JSON serialized value from the named embedded resource.
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected value as serialized JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The <see cref="ValueAssertor{TValue}"/> to support fluent-style method-chaining.</returns>
         public ValueAssertor<TValue> AssertJsonFromResource<TAssembly>(string resourceName, params string[] pathsToIgnore)

--- a/src/UnitTestEx/Expectations/ExpectationsArranger.cs
+++ b/src/UnitTestEx/Expectations/ExpectationsArranger.cs
@@ -107,7 +107,7 @@ namespace UnitTestEx.Expectations
         }
 
         /// <summary>
-        /// Resets any existing expectations back to their orginating assert state to allow for a re-execution.
+        /// Resets any existing expectations back to their originating assert state to allow for a re-execution.
         /// </summary>
         public void Reset()
         {

--- a/src/UnitTestEx/Expectations/ExpectationsExtensions.cs
+++ b/src/UnitTestEx/Expectations/ExpectationsExtensions.cs
@@ -227,7 +227,7 @@ namespace UnitTestEx.Expectations
         /// <typeparam name="TSelf">The expectations <see cref="Type"/>.</typeparam>
         /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
         /// <param name="expectations">The <see cref="IValueExpectations{TValue, TSelf}"/>.</param>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected value as serialized JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected value as serialized JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore.</param>
         /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
         /// <remarks>Uses <see cref="Resource.GetJson(string, Assembly?)"/> to load the embedded resource within the <see cref="Assembly.GetCallingAssembly"/>.</remarks>

--- a/src/UnitTestEx/Expectations/IExpectations.cs
+++ b/src/UnitTestEx/Expectations/IExpectations.cs
@@ -3,10 +3,15 @@
 namespace UnitTestEx.Expectations
 {
     /// <summary>
+    /// Enables the identification of a tester as having expectations capabilities.
+    /// </summary>
+    public interface IExpectations { }
+
+    /// <summary>
     /// Enables the <b>Expectations</b> fluent-style method-chaining capabilities.
     /// </summary>
     /// <typeparam name="TSelf">The <see cref="System.Type"/> representing itself.</typeparam>
-    public interface IExpectations<TSelf> where TSelf : IExpectations<TSelf>
+    public interface IExpectations<TSelf> : IExpectations where TSelf : IExpectations<TSelf>
     {
         /// <summary>
         /// Gets the <see cref="ExpectationsArranger{TSelf}"/>.

--- a/src/UnitTestEx/Hosting/EntryPoint.cs
+++ b/src/UnitTestEx/Hosting/EntryPoint.cs
@@ -11,7 +11,7 @@ namespace UnitTestEx.Hosting
     /// <summary>
     /// Provides a generic <see cref="EntryPoint"/> to support dependency injection.
     /// </summary>
-    /// <remarks>Uses reflection to map to the same named methods: <see cref="ConfigureAppConfiguration"/>, <see cref="ConfigureHostConfiguration"/> and <see cref="ConfigureServices"/>.</remarks>
+    /// <remarks>Uses reflection to map to the same named methods: <see cref="ConfigureAppConfiguration"/>, <see cref="ConfigureHostConfiguration"/> and <see cref="ConfigureServices"/>. These methods can be either instance or static methods.</remarks>
     public class EntryPoint
     {
         private readonly object _instance;
@@ -29,12 +29,12 @@ namespace UnitTestEx.Hosting
         public EntryPoint(object instance)
         {
             _instance = instance ?? throw new ArgumentNullException(nameof(instance));
-            _mi1 = instance.GetType().GetMethod(nameof(ConfigureAppConfiguration), BindingFlags.Instance | BindingFlags.Public, [typeof(HostBuilderContext), typeof(IConfigurationBuilder)]);
-            _mi2 = instance.GetType().GetMethod(nameof(ConfigureHostConfiguration), BindingFlags.Instance | BindingFlags.Public, [typeof(IConfigurationBuilder)]);
-            _mi3 = instance.GetType().GetMethod(nameof(ConfigureServices), BindingFlags.Instance | BindingFlags.Public, [typeof(IServiceCollection)]);
-            _mi3 = instance.GetType().GetMethod(nameof(ConfigureServices), BindingFlags.Instance | BindingFlags.Public, [typeof(IServiceCollection)]);
+            _mi1 = instance.GetType().GetMethod(nameof(ConfigureAppConfiguration), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(HostBuilderContext), typeof(IConfigurationBuilder)]);
+            _mi2 = instance.GetType().GetMethod(nameof(ConfigureHostConfiguration), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(IConfigurationBuilder)]);
+            _mi3 = instance.GetType().GetMethod(nameof(ConfigureServices), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(IServiceCollection)]);
+            _mi3 = instance.GetType().GetMethod(nameof(ConfigureServices), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(IServiceCollection)]);
 #if NET8_0_OR_GREATER
-            _mi4 = instance.GetType().GetMethod(nameof(ConfigureApplication), BindingFlags.Instance | BindingFlags.Public, [typeof(IHostApplicationBuilder)]);
+            _mi4 = instance.GetType().GetMethod(nameof(ConfigureApplication), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(IHostApplicationBuilder)]);
 #endif
         }
 

--- a/src/UnitTestEx/Hosting/EntryPoint.cs
+++ b/src/UnitTestEx/Hosting/EntryPoint.cs
@@ -32,7 +32,6 @@ namespace UnitTestEx.Hosting
             _mi1 = instance.GetType().GetMethod(nameof(ConfigureAppConfiguration), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(HostBuilderContext), typeof(IConfigurationBuilder)]);
             _mi2 = instance.GetType().GetMethod(nameof(ConfigureHostConfiguration), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(IConfigurationBuilder)]);
             _mi3 = instance.GetType().GetMethod(nameof(ConfigureServices), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(IServiceCollection)]);
-            _mi3 = instance.GetType().GetMethod(nameof(ConfigureServices), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(IServiceCollection)]);
 #if NET8_0_OR_GREATER
             _mi4 = instance.GetType().GetMethod(nameof(ConfigureApplication), BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, [typeof(IHostApplicationBuilder)]);
 #endif

--- a/src/UnitTestEx/Hosting/ScopedTypeTester.cs
+++ b/src/UnitTestEx/Hosting/ScopedTypeTester.cs
@@ -45,167 +45,216 @@ public class ScopedTypeTester<TService> : HostTesterBase<TService, ScopedTypeTes
     /// Runs the synchronous method with no result.
     /// </summary>
     /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
     /// <returns>A <see cref="VoidAssertor"/>.</returns>
-    public VoidAssertor Run(Action<TService> function) => RunAsync(x => { function(x); return Task.CompletedTask; }).GetAwaiter().GetResult();
+    public VoidAssertor Run(Action<TService> function, TesterArgs? args = null) => RunAsync(x => { function(x); return Task.CompletedTask; }, args).GetAwaiter().GetResult();
 
     /// <summary>
     /// Runs the synchronous method with a result.
     /// </summary>
     /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
     /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
     /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
-    public ValueAssertor<TValue> Run<TValue>(Func<TService, TValue> function) => RunAsync(x => Task.FromResult(function(x))).GetAwaiter().GetResult();
+    public ValueAssertor<TValue> Run<TValue>(Func<TService, TValue> function, TesterArgs? args = null) => RunAsync(x => Task.FromResult(function(x)), args).GetAwaiter().GetResult();
 
     /// <summary>
     /// Runs the asynchronous method with no result.
     /// </summary>
     /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
     /// <returns>A <see cref="VoidAssertor"/>.</returns>
 #if NET9_0_OR_GREATER
     [OverloadResolutionPriority(1)]
 #endif
-    public VoidAssertor Run(Func<TService, Task> function) => RunAsync(function).GetAwaiter().GetResult();
+    public VoidAssertor Run(Func<TService, Task> function, TesterArgs? args = null) => RunAsync(function, args).GetAwaiter().GetResult();
 
 #if NET9_0_OR_GREATER
     /// <summary>
     /// Runs the asynchronous method with no result.
     /// </summary>
     /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
     /// <returns>A <see cref="VoidAssertor"/>.</returns>
     [OverloadResolutionPriority(2)]
-    public VoidAssertor Run(Func<TService, ValueTask> function) => RunAsync(v => function(v).AsTask()).GetAwaiter().GetResult();
+    public VoidAssertor Run(Func<TService, ValueTask> function, TesterArgs? args = null) => RunAsync(v => function(v).AsTask(), args).GetAwaiter().GetResult();
 
 #endif
     /// <summary>
     /// Runs the asynchronous method with no result.
     /// </summary>
     /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
     /// <returns>A <see cref="VoidAssertor"/>.</returns>
 #if NET9_0_OR_GREATER
     [OverloadResolutionPriority(1)]
 #endif
-    public async Task<VoidAssertor> RunAsync(Func<TService, Task> function)
+    public async Task<VoidAssertor> RunAsync(Func<TService, Task> function, TesterArgs? args = null)
     {
-        TestSetUp.LogAutoSetUpOutputs(Implementor);
-
-        Exception? ex = null;
-        var sw = Stopwatch.StartNew();
-        LogHeader();
+        args ??= new TesterArgs();
+        _ = Owner.SharedState.GetLoggerMessages();
 
         try
         {
-            await (function ?? throw new ArgumentNullException(nameof(function)))(Service).ConfigureAwait(false);
-        }
-        catch (AggregateException aex)
-        {
-            ex = aex.InnerException ?? aex;
-        }
-        catch (Exception uex)
-        {
-            ex = uex;
-        }
-        finally
-        {
-            sw.Stop();
-        }
+            TestSetUp.LogAutoSetUpOutputs(Implementor);
 
-        await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
-        var logs = Owner.SharedState.GetLoggerMessages();
-        LogResult(ex, sw.Elapsed.TotalMilliseconds, logs);
+            if (!args.BypassRunActions)
+                Owner.ExecutePreRunActions(this);
 
-        await ExpectationsArranger.AssertAsync(logs, ex).ConfigureAwait(false);
+            Exception? ex = null;
+            var sw = Stopwatch.StartNew();
+            LogHeader();
 
-        return new VoidAssertor(Owner, ex);
-    }
-
-#if NET9_0_OR_GREATER
-    /// <summary>
-    /// Runs the asynchronous method with no result.
-    /// </summary>
-    /// <param name="function">The function execution.</param>
-    /// <returns>A <see cref="VoidAssertor"/>.</returns>
-    [OverloadResolutionPriority(2)]
-    public async Task<VoidAssertor> RunAsync(Func<TService, ValueTask> function) => await RunAsync(v => function(v).AsTask()).ConfigureAwait(false);
-
-#endif
-    /// <summary>
-    /// Runs the asynchronous method with a result.
-    /// </summary>
-    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
-    /// <param name="function">The function execution.</param>
-    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
-#if NET9_0_OR_GREATER
-    [OverloadResolutionPriority(1)]
-#endif
-    public ValueAssertor<TValue> Run<TValue>(Func<TService, Task<TValue>> function) => RunAsync(function).GetAwaiter().GetResult();
-
-#if NET9_0_OR_GREATER
-    /// <summary>
-    /// Runs the asynchronous method with a result.
-    /// </summary>
-    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
-    /// <param name="function">The function execution.</param>
-    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
-    [OverloadResolutionPriority(2)]
-    public ValueAssertor<TValue> Run<TValue>(Func<TService, ValueTask<TValue>> function) => RunAsync(v => function(v).AsTask()).GetAwaiter().GetResult();
-
-#endif
-    /// <summary>
-    /// Runs the asynchronous method with a result.
-    /// </summary>
-    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
-    /// <param name="function">The function execution.</param>
-    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
-#if NET9_0_OR_GREATER
-    [OverloadResolutionPriority(1)]
-#endif
-    public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<TService, Task<TValue>> function)
-    {
-        TestSetUp.LogAutoSetUpOutputs(Implementor);
-
-        TValue result = default!;
-        Exception? ex = null;
-        var sw = Stopwatch.StartNew();
-        LogHeader();
-
-        try
-        {
-            result = await (function ?? throw new ArgumentNullException(nameof(function)))(Service).ConfigureAwait(false);
-        }
-        catch (AggregateException aex)
-        {
-            ex = aex.InnerException ?? aex;
-        }
-        catch (Exception uex)
-        {
-            ex = uex;
-        }
-        finally
-        {
-            sw.Stop();
-        }
-
-        await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
-        var logs = Owner.SharedState.GetLoggerMessages();
-        LogResult(ex, sw.Elapsed.TotalMilliseconds, logs);
-
-        if (ex == null)
-        {
-            if (result is string str)
-                Implementor.WriteLine($"Result: {str}");
-            else if (result is IFormattable ifm)
-                Implementor.WriteLine($"Result: {ifm.ToString(null, CultureInfo.CurrentCulture)}");
-            else
+            try
             {
-                Implementor.WriteLine($"Result: {(result == null ? "<null>" : result.GetType().Name)}");
-                if (result != null)
-                    Implementor.WriteLine(JsonSerializer.Serialize<dynamic>(result, JsonWriteFormat.Indented));
+                await (function ?? throw new ArgumentNullException(nameof(function)))(Service).ConfigureAwait(false);
             }
+            catch (AggregateException aex)
+            {
+                ex = aex.InnerException ?? aex;
+            }
+            catch (Exception uex)
+            {
+                ex = uex;
+            }
+            finally
+            {
+                sw.Stop();
+            }
+
+            await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
+            var logs = Owner.SharedState.GetLoggerMessages();
+            LogResult(ex, sw.Elapsed.TotalMilliseconds, logs);
+
+            if (!args.BypassRunActions)
+                Owner.ExecutePostRunBeforeExpectationsActions(this);
+
+            await ExpectationsArranger.AssertAsync(logs, ex).ConfigureAwait(false);
+
+            if (!args.BypassRunActions)
+                Owner.ExecutePostRunAfterExpectationsActions(this);
+
+            return new VoidAssertor(Owner, ex);
         }
+        finally
+        {
+            if (!args.BypassRunActions)
+                Owner.ExecutePostRunActions(this);
+        }
+    }
 
-        await ExpectationsArranger.AssertValueAsync(logs, result, ex).ConfigureAwait(false);
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Runs the asynchronous method with no result.
+    /// </summary>
+    /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
+    /// <returns>A <see cref="VoidAssertor"/>.</returns>
+    [OverloadResolutionPriority(2)]
+    public async Task<VoidAssertor> RunAsync(Func<TService, ValueTask> function, TesterArgs? args = null) => await RunAsync(v => function(v).AsTask(), args).ConfigureAwait(false);
 
-        return new ValueAssertor<TValue>(Owner, result, ex);
+#endif
+    /// <summary>
+    /// Runs the asynchronous method with a result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+    /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
+    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+#if NET9_0_OR_GREATER
+    [OverloadResolutionPriority(1)]
+#endif
+    public ValueAssertor<TValue> Run<TValue>(Func<TService, Task<TValue>> function, TesterArgs? args = null) => RunAsync(function, args).GetAwaiter().GetResult();
+
+#if NET9_0_OR_GREATER
+    /// <summary>
+    /// Runs the asynchronous method with a result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+    /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
+    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+    [OverloadResolutionPriority(2)]
+    public ValueAssertor<TValue> Run<TValue>(Func<TService, ValueTask<TValue>> function, TesterArgs? args = null) => RunAsync(v => function(v).AsTask(), args).GetAwaiter().GetResult();
+
+#endif
+    /// <summary>
+    /// Runs the asynchronous method with a result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
+    /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
+    /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
+#if NET9_0_OR_GREATER
+    [OverloadResolutionPriority(1)]
+#endif
+    public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<TService, Task<TValue>> function, TesterArgs? args = null)
+    {
+        args ??= new TesterArgs();
+        _ = Owner.SharedState.GetLoggerMessages();
+
+        try
+        {
+            TestSetUp.LogAutoSetUpOutputs(Implementor);
+
+            if (!args.BypassRunActions)
+                Owner.ExecutePreRunActions(this);
+
+            TValue result = default!;
+            Exception? ex = null;
+            var sw = Stopwatch.StartNew();
+            LogHeader();
+
+            try
+            {
+                result = await (function ?? throw new ArgumentNullException(nameof(function)))(Service).ConfigureAwait(false);
+            }
+            catch (AggregateException aex)
+            {
+                ex = aex.InnerException ?? aex;
+            }
+            catch (Exception uex)
+            {
+                ex = uex;
+            }
+            finally
+            {
+                sw.Stop();
+            }
+
+            await Task.Delay(TestSetUp.TaskDelayMilliseconds).ConfigureAwait(false);
+            var logs = Owner.SharedState.GetLoggerMessages();
+            LogResult(ex, sw.Elapsed.TotalMilliseconds, logs);
+
+            if (ex == null)
+            {
+                if (result is string str)
+                    Implementor.WriteLine($"Result: {str}");
+                else if (result is IFormattable ifm)
+                    Implementor.WriteLine($"Result: {ifm.ToString(null, CultureInfo.CurrentCulture)}");
+                else
+                {
+                    Implementor.WriteLine($"Result: {(result == null ? "<null>" : result.GetType().Name)}");
+                    if (result != null)
+                        Implementor.WriteLine(JsonSerializer.Serialize<dynamic>(result, JsonWriteFormat.Indented));
+                }
+            }
+
+            if (!args.BypassRunActions)
+                Owner.ExecutePostRunBeforeExpectationsActions(this);
+
+            await ExpectationsArranger.AssertValueAsync(logs, result, ex).ConfigureAwait(false);
+
+            if (!args.BypassRunActions)
+                Owner.ExecutePostRunAfterExpectationsActions(this);
+
+            return new ValueAssertor<TValue>(Owner, result, ex);
+        }
+        finally
+        {
+            if (!args.BypassRunActions)
+                Owner.ExecutePostRunActions(this);
+        }
     }
 
 #if NET9_0_OR_GREATER
@@ -214,9 +263,10 @@ public class ScopedTypeTester<TService> : HostTesterBase<TService, ScopedTypeTes
     /// </summary>
     /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
     /// <param name="function">The function execution.</param>
+    /// <param name="args">The optional <see cref="TesterArgs"/>.</param>
     /// <returns>A <see cref="ValueAssertor{TValue}"/>.</returns>
     [OverloadResolutionPriority(2)]
-    public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<TService, ValueTask<TValue>> function) => await RunAsync(v => function(v).AsTask()).ConfigureAwait(false);
+    public async Task<ValueAssertor<TValue>> RunAsync<TValue>(Func<TService, ValueTask<TValue>> function, TesterArgs? args = null) => await RunAsync(v => function(v).AsTask(), args).ConfigureAwait(false);
 
 #endif
     /// <summary>

--- a/src/UnitTestEx/Mocking/MockHttpClient.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClient.cs
@@ -331,14 +331,14 @@ namespace UnitTestEx.Mocking
         /// Adds mocked request(s) from the embedded resource formatted as either YAML or JSON.
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> used to infer <see cref="Assembly"/> that contains the embedded resource.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <returns></returns>
         public MockHttpClient WithRequestsFromResource<TAssembly>(string resourceName) => WithRequestsFromResource(resourceName, typeof(TAssembly).Assembly);
 
         /// <summary>
         /// Adds mocked request(s) from the embedded resource formatted as either YAML or JSON.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetCallingAssembly"/>.</param>
         /// <returns>The <see cref="MockHttpClient"/> to support fluent-style method-chaining.</returns>
         public MockHttpClient WithRequestsFromResource(string resourceName, Assembly? assembly = null)

--- a/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientRequest.cs
@@ -240,11 +240,28 @@ namespace UnitTestEx.Mocking
         }
 
         /// <summary>
+        /// Reset to initial state; ensure consistency to allow reuse of the same <see cref="MockHttpClientRequest"/> instance.
+        /// </summary>
+        private void Reset()
+        {
+            IsMockComplete = false;
+            _anyContent = false;
+            _content = null;
+            _mediaType = null;
+            _pathsToIgnore = [];
+            _traceRequestComparisons = false;
+
+            Rule.Reset();
+            Rule.Response = new MockHttpClientResponse(this, Rule);
+        }
+
+        /// <summary>
         /// Enables <i>any</i> request with <i>a</i> body (functionally equivalent to <see cref="ItExpr.IsAny{TValue}"/>).
         /// </summary>
         /// <returns>The resulting <see cref="MockHttpClientRequestBody"/> to <see cref="MockHttpClientRequestBody.Respond"/> accordingly.</returns>
         public MockHttpClientRequestBody WithAnyBody()
         {
+            Reset();
             _anyContent = true;
             _mediaType = MediaTypeNames.Text.Plain;
             return new MockHttpClientRequestBody(Rule);
@@ -257,6 +274,7 @@ namespace UnitTestEx.Mocking
         /// <returns>The resulting <see cref="MockHttpClientRequestBody"/> to <see cref="MockHttpClientRequestBody.Respond"/> accordingly.</returns>
         public MockHttpClientRequestBody WithBody(string text)
         {
+            Reset();
             _content = text;
             _mediaType = MediaTypeNames.Text.Plain; 
             return new MockHttpClientRequestBody(Rule);
@@ -270,6 +288,7 @@ namespace UnitTestEx.Mocking
         /// <returns>The resulting <see cref="MockHttpClientRequestBody"/> to <see cref="MockHttpClientRequestBody.Respond"/> accordingly.</returns>
         public MockHttpClientRequestBody WithBody(string body, string mediaType)
         {
+            Reset();
             _content = body;
             _mediaType = mediaType;
             return new MockHttpClientRequestBody(Rule);
@@ -284,6 +303,7 @@ namespace UnitTestEx.Mocking
         /// <returns>The resulting <see cref="MockHttpClientRequestBody"/> to <see cref="MockHttpClientRequestBody.Respond"/> accordingly.</returns>
         public MockHttpClientRequestBody WithJsonBody<T>(T value, params string[] pathsToIgnore)
         {
+            Reset();
             _content = value;
             _mediaType = MediaTypeNames.Application.Json;
             _pathsToIgnore = pathsToIgnore;
@@ -302,6 +322,8 @@ namespace UnitTestEx.Mocking
         public MockHttpClientRequestBody WithJsonBody(string json, params string[] pathsToIgnore)
 #endif
         {
+            Reset();
+
             try
             {
                 _ = JsonSerializer.Deserialize(json);
@@ -320,7 +342,7 @@ namespace UnitTestEx.Mocking
         /// Provides the expected request body using the JSON formatted embedded resource as the content (<see cref="MediaTypeNames.Application.Json"/>).
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> used to infer <see cref="Assembly"/> that contains the embedded resource.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The resulting <see cref="MockHttpClientRequestBody"/> to <see cref="MockHttpClientRequestBody.Respond"/> accordingly.</returns>
         public MockHttpClientRequestBody WithJsonResourceBody<TAssembly>(string resourceName, params string[] pathsToIgnore) => WithJsonResourceBody(resourceName, typeof(TAssembly).Assembly, pathsToIgnore);
@@ -328,12 +350,13 @@ namespace UnitTestEx.Mocking
         /// <summary>
         /// Provides the expected request body using the JSON formatted embedded resource as the content (<see cref="MediaTypeNames.Application.Json"/>).
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetCallingAssembly"/>.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         /// <returns>The resulting <see cref="MockHttpClientRequestBody"/> to <see cref="MockHttpClientRequestBody.Respond"/> accordingly.</returns>
         public MockHttpClientRequestBody WithJsonResourceBody(string resourceName, Assembly? assembly = null, params string[] pathsToIgnore)
         {
+            Reset();
             _content = Resource.GetJson(resourceName, assembly ?? Assembly.GetCallingAssembly());
             _pathsToIgnore = pathsToIgnore;
             _mediaType = MediaTypeNames.Application.Json;

--- a/src/UnitTestEx/Mocking/MockHttpClientRequestRule.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientRequestRule.cs
@@ -38,7 +38,7 @@ namespace UnitTestEx.Mocking
         /// <summary>
         /// Resets the rule to the default values.
         /// </summary>
-        /// <remarks>Does not reset the <see cref="Response"/> or <see cref="Times"/>.</remarks>
+        /// <remarks>Does not reset <see cref="Times"/>; the <see cref="Response"/> should be immediately updated post invocation to avoid runtime issues.</remarks>
         internal void Reset()
         {
             Body = null;

--- a/src/UnitTestEx/Mocking/MockHttpClientRequestRule.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientRequestRule.cs
@@ -34,5 +34,17 @@ namespace UnitTestEx.Mocking
         /// Gets or sets the number of <see cref="Moq.Times"/>.
         /// </summary>
         internal Times? Times { get; set; }
+
+        /// <summary>
+        /// Resets the rule to the default values.
+        /// </summary>
+        /// <remarks>Does not reset the <see cref="Response"/> or <see cref="Times"/>.</remarks>
+        internal void Reset()
+        {
+            Body = null;
+            Response = null;
+            Responses = null;
+            ResponsesIndex = 0;
+        }
     }
 }

--- a/src/UnitTestEx/Mocking/MockHttpClientResponse.cs
+++ b/src/UnitTestEx/Mocking/MockHttpClientResponse.cs
@@ -104,16 +104,16 @@ namespace UnitTestEx.Mocking
         /// <summary>
         /// Sets the simulated delay (sleep) for the response.
         /// </summary>
-        /// <param name="millseconds">The delay (sleep) milliseconds.</param>
+        /// <param name="milliseconds">The delay (sleep) milliseconds.</param>
         /// <returns>The <see cref="MockHttpClientResponse"/> to support fluent-style method-chaining.</returns>
         /// <remarks>Each time a <c>Delay</c> is invoked it will override the previously set value.</remarks>
-        public MockHttpClientResponse Delay(int millseconds) => Delay(TimeSpan.FromMilliseconds(millseconds));
+        public MockHttpClientResponse Delay(int milliseconds) => Delay(TimeSpan.FromMilliseconds(milliseconds));
 
         /// <summary>
         /// Sets the simulated delay (sleep) as a random between the <paramref name="from"/> and <paramref name="to"/> values for the response.
         /// </summary>
         /// <param name="from">The from milliseconds.</param>
-        /// <param name="to">The to millseconds.</param>
+        /// <param name="to">The to milliseconds.</param>
         /// <returns>The <see cref="MockHttpClientResponse"/> to support fluent-style method-chaining.</returns>
         /// <remarks>Each time a <c>Delay</c> is invoked it will override the previously set value.</remarks>
         public MockHttpClientResponse Delay(int from, int to) => Delay(TimeSpan.FromMilliseconds(from), TimeSpan.FromMilliseconds(to));
@@ -221,7 +221,7 @@ namespace UnitTestEx.Mocking
         /// Provides the mocked response using the JSON formatted embedded resource string as the content.
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> used to infer <see cref="Assembly"/> that contains the embedded resource.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="statusCode">The optional <see cref="HttpStatusCode"/> (defaults to <see cref="HttpStatusCode.OK"/>).</param>
         /// <param name="mediaType">The optional media type (defaults to <see cref="MediaTypeNames.Application.Json"/>).</param>
         /// <param name="response">The optional action to enable additional configuration of the <see cref="HttpResponseMessage"/>.</param>
@@ -231,7 +231,7 @@ namespace UnitTestEx.Mocking
         /// <summary>
         /// Provides the mocked response using the JSON formatted embedded resource string as the content.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="statusCode">The optional <see cref="HttpStatusCode"/> (defaults to <see cref="HttpStatusCode.OK"/>).</param>
         /// <param name="mediaType">The optional media type (defaults to <see cref="MediaTypeNames.Application.Json"/>).</param>
         /// <param name="response">The optional action to enable additional configuration of the <see cref="HttpResponseMessage"/>.</param>

--- a/src/UnitTestEx/ObjectComparer.cs
+++ b/src/UnitTestEx/ObjectComparer.cs
@@ -138,7 +138,7 @@ namespace UnitTestEx
         /// <summary>
         /// Compares two JSON strings to each other where the expected JSON is from an embedded resource.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected JSON.</param>
         /// <param name="actual">The actual JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         public static void AssertJsonFromResource(string resourceName, string? actual, params string[] pathsToIgnore)
@@ -148,7 +148,7 @@ namespace UnitTestEx
         /// Compares two JSON strings to each other where the expected JSON is from an embedded resource.
         /// </summary>
         /// <typeparam name="TAssembly">The <see cref="Type"/> to infer the <see cref="Assembly"/> that contains the embedded resource.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name) that contains the expected JSON.</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name) that contains the expected JSON.</param>
         /// <param name="actual">The actual JSON.</param>
         /// <param name="pathsToIgnore">The JSON paths to ignore from the comparison.</param>
         public static void AssertJsonFromResource<TAssembly>(string resourceName, string? actual, params string[] pathsToIgnore)

--- a/src/UnitTestEx/Resource.cs
+++ b/src/UnitTestEx/Resource.cs
@@ -19,7 +19,7 @@ namespace UnitTestEx
         /// <summary>
         /// Gets the named embedded resource <see cref="StreamReader"/>.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetCallingAssembly"/>.</param>
         /// <returns>The <see cref="StreamReader"/>; otherwise, an <see cref="ArgumentException"/> will be thrown.</returns>
         public static StreamReader GetStream(string resourceName, Assembly? assembly = null)
@@ -38,7 +38,7 @@ namespace UnitTestEx
         /// <summary>
         /// Gets the named embedded resource as a <see cref="string"/>.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetCallingAssembly"/>.</param>
         /// <returns>The JSON <see cref="string"/>.</returns>
         public static string GetString(string resourceName, Assembly? assembly = null)
@@ -51,7 +51,7 @@ namespace UnitTestEx
         /// Gets the value by deserializing the JSON within the named embedded resource to the specified <see cref="Type"/> of <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The value <see cref="Type"/>.</typeparam>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetCallingAssembly"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>; defaults to <see cref="JsonSerializer.Default"/>.</param>
         /// <returns>The deserialized value.</returns>
@@ -64,7 +64,7 @@ namespace UnitTestEx
         /// <summary>
         /// Gets the named embedded resource as a validated JSON <see cref="string"/>.
         /// </summary>
-        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
+        /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualified resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetCallingAssembly"/>.</param>
         /// <returns>The JSON <see cref="string"/>.</returns>
         public static string GetJson(string resourceName, Assembly? assembly = null)

--- a/src/UnitTestEx/TestSetUp.cs
+++ b/src/UnitTestEx/TestSetUp.cs
@@ -242,7 +242,7 @@ namespace UnitTestEx
         }
 
         /// <summary>
-        /// Executes the registered set up synchronsously.
+        /// Executes the registered set up synchronously.
         /// </summary>
         /// <param name="data">The optional data.</param>
         /// <returns><c>true</c> indicates that the set up was successful; otherwise, <c>false</c>.</returns>
@@ -250,7 +250,7 @@ namespace UnitTestEx
         public bool SetUp(object? data = null) => SetUpAsync(data).GetAwaiter().GetResult();
 
         /// <summary>
-        /// Executes the registered set up asynchronsously.
+        /// Executes the registered set up asynchronously.
         /// </summary>
         /// <param name="data">The optional data.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/src/UnitTestEx/TesterArgs.cs
+++ b/src/UnitTestEx/TesterArgs.cs
@@ -1,0 +1,16 @@
+﻿using UnitTestEx.Abstractions;
+
+namespace UnitTestEx
+{
+    /// <summary>
+    /// Provides per tester arguments that can be used to control the tester behavior.
+    /// </summary>
+    public class TesterArgs
+    {
+        /// <summary>
+        /// Indicates whether to bypass the execution of the configured run actions.
+        /// </summary>
+        /// <remarks>The run actions are: <see cref="TesterBase.PreRunActions"/>, <see cref="TesterBase.PostRunBeforeExpectationsActions"/> and <see cref="TesterBase.PostRunAfterExpectationsActions"/>.</remarks>
+        public bool BypassRunActions { get; set; }
+    }
+}

--- a/tests/UnitTestEx.NUnit.Test/MockHttpClientTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/MockHttpClientTest.cs
@@ -164,8 +164,9 @@ namespace UnitTestEx.NUnit.Test
         public async Task UriAndBody_WithJsonResponse3()
         {
             var mcf = MockHttpClientFactory.Create();
-            mcf.CreateClient("XXX", new Uri("https://d365test"))
-                .Request(HttpMethod.Post, "products/xyz").WithJsonBody(new Person { FirstName = "Bob", LastName = "Jane" })
+            var req = mcf.CreateClient("XXX", new Uri("https://d365test")).Request(HttpMethod.Post, "products/xyz");
+
+            req.WithJsonBody(new Person { FirstName = "Bob", LastName = "Jane" })
                 .Respond.WithJsonResource("MockHttpClientTest-UriAndBody_WithJsonResponse3.json", HttpStatusCode.Accepted);
 
             var hc = mcf.GetHttpClient("XXX");
@@ -175,6 +176,41 @@ namespace UnitTestEx.NUnit.Test
                 Assert.That(res.StatusCode, Is.EqualTo(HttpStatusCode.Accepted));
                 Assert.That(await res.Content.ReadAsStringAsync().ConfigureAwait(false), Is.EqualTo("{\"first\":\"Bob\",\"last\":\"Jane\"}"));
             });
+
+            // Change up the request body and now should fail.
+            req.WithJsonBody(new Person { FirstName = "Bob", LastName = "Janet" })
+                .Respond.WithJsonResource("MockHttpClientTest-UriAndBody_WithJsonResponse3.json", HttpStatusCode.Accepted);
+
+            try
+            { 
+                res = await hc.PostAsJsonAsync("products/xyz", new Person { LastName = "Jane", FirstName = "Bob" }).ConfigureAwait(false);
+                Assert.Fail();
+            }
+            catch (MockHttpClientException mhcex)
+            {
+                Assert.That(mhcex.Message, Is.EqualTo("No corresponding MockHttpClient response found for HTTP request POST https://d365test/products/xyz {\"firstName\":\"Bob\",\"lastName\":\"Jane\"} (application/json)"));
+            }
+        }
+
+        [Test]
+        public async Task Mock_Request_Not_Found()
+        {
+            var mcf = MockHttpClientFactory.Create();
+            var req = mcf.CreateClient("XXX", new Uri("https://d365test")).Request(HttpMethod.Post, "products/xyz");
+            
+            req.WithJsonBody(new Person { FirstName = "Bob", LastName = "Jane" })
+                .Respond.WithJsonResource("MockHttpClientTest-UriAndBody_WithJsonResponse3.json", HttpStatusCode.Accepted);
+
+            var hc = mcf.GetHttpClient("XXX");
+            try
+            {
+                var res = await hc.PostAsJsonAsync("products/xyz", new Person { LastName = "Jane", FirstName = "Bobby" }).ConfigureAwait(false);
+                Assert.Fail();
+            }
+            catch (MockHttpClientException mhcex)
+            {
+                Assert.That(mhcex.Message, Is.EqualTo("No corresponding MockHttpClient response found for HTTP request POST https://d365test/products/xyz {\"firstName\":\"Bobby\",\"lastName\":\"Jane\"} (application/json)"));
+            }
         }
 
         [Test]

--- a/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/GenericTest.cs
@@ -110,7 +110,7 @@ namespace UnitTestEx.NUnit.Test.Other
 
         //public void ConfigureServices(IServiceCollection services) { }
 
-        public void ConfigureApplication(IHostApplicationBuilder builder)
+        public static void ConfigureApplication(IHostApplicationBuilder builder)
         {
             builder.Services.AddSingleton<Gin>();
         }

--- a/tests/UnitTestEx.NUnit.Test/Other/ObjectComparerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/Other/ObjectComparerTest.cs
@@ -21,5 +21,14 @@ namespace UnitTestEx.NUnit.Test.Other
             var p2 = new Person { FirstName = "Wendy", LastName = "YYY" };
             ObjectComparer.Assert(p1, p2, "LastName");
         }
+
+        [Test]
+        public void PathsToIgnore_Json()
+        {
+            // Starting array and object are ignored, so the path to ignore is just the property name.
+            var j1 = @"[ { ""FirstName"": ""Wendy"", ""LastName"": ""XXX"" } ]";
+            var j2 = @"[ { ""FirstName"": ""Wendy"", ""LastName"": ""YYY"" } ]";
+            ObjectComparer.AssertJson(j1, j2, "LastName");
+        }
     }
 }

--- a/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
@@ -149,8 +149,8 @@ namespace UnitTestEx.NUnit.Test
                 .Run(c => c.Update(1, new Person { FirstName = null, LastName = null }))
                 .AssertBadRequest()
                 .AssertErrors(
-                    new ApiError("firstName", "First name is required."),
-                    new ApiError("lastName", "Last name is required."));
+                    ("firstName", "First name is required."),
+                    "Last name is required.");
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace UnitTestEx.NUnit.Test
                     .Run(c => c.Update(1, new Person { FirstName = null, LastName = null }));
             });
 
-            Assert.That(ex.Message, Does.Contain("Error: First name is requiredx."));
+            Assert.That(ex.Message, Does.Contain("null: First name is requiredx."));
         }
 
         [Test]


### PR DESCRIPTION
- [x] Fix `HttpTesterBase.cs` `finally` block incorrectly calling `ExecutePreRunActions` instead of `ExecutePostRunActions`

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
