### PR TITLE
v5.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Represents the **NuGet** versions.
 
 ## v5.11.0
-- *Enhancement:* Added `AssertorBase.Logs` to enable access to the logs captured during execution of the test for assertion purposes. This is intended to be used in conjunction with the existing `ExpectLogContains` expectation to enable additional (more advanced) assertions against the logs.
+- *Enhancement:* Added `AssertorBase.LogMessages` to enable access to the logs captured during execution of the test for assertion purposes. This is intended to be used in conjunction with the existing `ExpectLogContains` expectation to enable additional (more advanced) assertions against the logs.
 
 ## v5.10.0
 - *Enhancement:* `TestSharedState` updated to enable request-based (isolated) state; with the corresponding `GetHttpRequestId()` method now made public.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.11.0
+- *Enhancement:* Added `AssertorBase.Logs` to enable access to the logs captured during execution of the test for assertion purposes. This is intended to be used in conjunction with the existing `ExpectLogContains` expectation to enable additional (more advanced) assertions against the logs.
+
 ## v5.10.0
 - *Enhancement:* `TestSharedState` updated to enable request-based (isolated) state; with the corresponding `GetHttpRequestId()` method now made public.
 - *Enhancement:* Added `ApiTesterBase.AddPreRunAction()`, `AddPostRunBeforeExpectationsAction()`, `AddPostRunAfterExpectationsAction()` and `AddPostRunAction()` to enable the addition of actions to be executed at different stages of the `Run`/`RunAsync` process for every underlying test. This will enable the addition of common pre/post processing logic without having to explicitly add to each test.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>5.10.0</Version>
+		<Version>5.11.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/HttpTriggerTester.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/HttpTriggerTester.cs
@@ -146,7 +146,7 @@ namespace UnitTestEx.Azure.Functions
 
             await ExpectationsArranger.AssertAsync(logs, ex).ConfigureAwait(false);
 
-            return new ActionResultAssertor(Owner, result, ex);
+            return new ActionResultAssertor(Owner, result, logs, ex);
         }
 
         private void CheckRoute(HttpRequest request, string? route, (string? Name, object? Value)[] @params)

--- a/src/UnitTestEx.Azure.Functions/Azure/Functions/ServiceBusTriggerTester.cs
+++ b/src/UnitTestEx.Azure.Functions/Azure/Functions/ServiceBusTriggerTester.cs
@@ -98,7 +98,7 @@ namespace UnitTestEx.Azure.Functions
 
             await ExpectationsArranger.AssertAsync(logs, ex).ConfigureAwait(false);
 
-            return new VoidAssertor(Owner, ex);
+            return new VoidAssertor(Owner, logs, ex);
         }
 
         /// <summary>

--- a/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
+++ b/src/UnitTestEx/AspNetCore/HttpTesterBase.cs
@@ -100,7 +100,7 @@ namespace UnitTestEx.AspNetCore
                 Owner.ExecutePostRunBeforeExpectationsActions(this);
                 await AssertExpectationsAsync(res).ConfigureAwait(false);
                 Owner.ExecutePostRunAfterExpectationsActions(this);
-                return new HttpResponseMessageAssertor(Owner, res);
+                return new HttpResponseMessageAssertor(Owner, LastLogs, res);
             }
             finally
             {
@@ -136,7 +136,7 @@ namespace UnitTestEx.AspNetCore
                 Owner.ExecutePostRunBeforeExpectationsActions(this);
                 await AssertExpectationsAsync(res).ConfigureAwait(false);
                 Owner.ExecutePostRunAfterExpectationsActions(this);
-                return new HttpResponseMessageAssertor(Owner, res);
+                return new HttpResponseMessageAssertor(Owner, LastLogs, res);
             }
             finally
             {
@@ -171,7 +171,7 @@ namespace UnitTestEx.AspNetCore
                 Owner.ExecutePostRunBeforeExpectationsActions(this);
                 await AssertExpectationsAsync(res).ConfigureAwait(false);
                 Owner.ExecutePostRunAfterExpectationsActions(this);
-                return new HttpResponseMessageAssertor(Owner, res);
+                return new HttpResponseMessageAssertor(Owner, LastLogs, res);
             }
             finally
             {

--- a/src/UnitTestEx/Assertors/ActionResultAssertor.cs
+++ b/src/UnitTestEx/Assertors/ActionResultAssertor.cs
@@ -24,8 +24,9 @@ namespace UnitTestEx.Assertors
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
     /// <param name="result">The <see cref="IActionResult"/>.</param>
+    /// <param name="logs">The logs captured during execution.</param>
     /// <param name="exception">The <see cref="Exception"/> (if any).</param>
-    public class ActionResultAssertor(TesterBase owner, IActionResult result, Exception? exception) : AssertorBase<ActionResultAssertor>(owner, exception)
+    public class ActionResultAssertor(TesterBase owner, IActionResult result, IEnumerable<string?>? logs, Exception? exception) : AssertorBase<ActionResultAssertor>(owner, logs, exception)
     {
         /// <summary>
         /// Gets the <see cref="IActionResult"/>.
@@ -485,16 +486,17 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/> with <see cref="HttpContext"/>; otherwise, will default.</param>
         /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
-        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor(HttpRequest? httpRequest = null) => ToHttpResponseMessageAssertor(Owner, Result, httpRequest);
+        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor(HttpRequest? httpRequest = null) => ToHttpResponseMessageAssertor(Owner, Result, LogMessages, httpRequest);
 
         /// <summary>
         /// Converts the <see cref="ValueAssertor{TValue}"/> to an <see cref="HttpResponseMessageAssertor"/>.
         /// </summary>
         /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
         /// <param name="result">The <see cref="IActionResult"/> to convert.</param>
+        /// <param name="logs">The log messages captured during execution.</param>
         /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/>; otherwise, will default.</param>
         /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
-        internal static HttpResponseMessageAssertor ToHttpResponseMessageAssertor(TesterBase owner, IActionResult result, HttpRequest? httpRequest)
+        internal static HttpResponseMessageAssertor ToHttpResponseMessageAssertor(TesterBase owner, IActionResult result, IEnumerable<string?>? logs, HttpRequest? httpRequest)
         {
             var sw = Stopwatch.StartNew();
             using var ms = new MemoryStream();
@@ -517,7 +519,7 @@ namespace UnitTestEx.Assertors
             sw.Stop();
             owner.LogHttpResponseMessage(hr, sw);
 
-            return new HttpResponseMessageAssertor(owner, hr);
+            return new HttpResponseMessageAssertor(owner, logs, hr);
         }
     }
 }

--- a/src/UnitTestEx/Assertors/AssertorBase.cs
+++ b/src/UnitTestEx/Assertors/AssertorBase.cs
@@ -11,8 +11,9 @@ namespace UnitTestEx.Assertors
     /// Represents the base test assert helper.
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="logs">The logs captured during execution.</param>
     /// <param name="exception">The <see cref="Exception"/> (if any).</param>
-    public abstract class AssertorBase(TesterBase owner, Exception? exception)
+    public abstract class AssertorBase(TesterBase owner, IEnumerable<string?>? logs, Exception? exception)
     {
         private static List<Func<AssertorBase, ApiError[], bool>>? _assertErrorsExtentions;
 
@@ -27,6 +28,11 @@ namespace UnitTestEx.Assertors
         /// Gets the owning <see cref="TesterBase"/>.
         /// </summary>
         public TesterBase Owner { get; } = owner ?? throw new ArgumentNullException(nameof(owner));
+
+        /// <summary>
+        /// Gets the log messages captured during execution.
+        /// </summary>
+        public IEnumerable<string?> LogMessages { get; } = logs ?? [];
 
         /// <summary>
         /// Gets the <see cref="System.Exception"/>.
@@ -58,7 +64,7 @@ namespace UnitTestEx.Assertors
                         return;
                 }
 
-                if (!Assertor.TryAreErrorsMatched(errors, Array.Empty<ApiError>(), out var errorMessage))
+                if (!Assertor.TryAreErrorsMatched(errors, [], out var errorMessage))
                     Implementor.AssertFail(errorMessage);
             }
         }

--- a/src/UnitTestEx/Assertors/AssertorBaseT.cs
+++ b/src/UnitTestEx/Assertors/AssertorBaseT.cs
@@ -10,8 +10,9 @@ namespace UnitTestEx.Assertors
     /// Represents the base test assert helper that distinguishes between <see cref="AssertException"/> and <see cref="AssertSuccess"/>.
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="logs">The logs captured during execution.</param>
     /// <param name="exception">The <see cref="Exception"/> (if any).</param>
-    public abstract class AssertorBase<TSelf>(TesterBase owner, Exception? exception) : AssertorBase(owner, exception) where TSelf : AssertorBase<TSelf>
+    public abstract class AssertorBase<TSelf>(TesterBase owner, IEnumerable<string?>? logs, Exception? exception) : AssertorBase(owner, logs, exception) where TSelf : AssertorBase<TSelf>
     {
         /// <summary>
         /// Asserts that an <see cref="Exception"/> was thrown during execution.

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertor.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertor.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Net.Http.Headers;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
@@ -13,8 +14,9 @@ namespace UnitTestEx.Assertors
     /// Represents the <see cref="HttpResponseMessage"/> test assert helper.
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="logs">The log messages captured during execution.</param>
     /// <param name="response">The <see cref="HttpResponseMessage"/>.</param>
-    public class HttpResponseMessageAssertor(TesterBase owner, HttpResponseMessage response) : HttpResponseMessageAssertorBase<HttpResponseMessageAssertor>(owner, response)
+    public class HttpResponseMessageAssertor(TesterBase owner, IEnumerable<string?>? logs, HttpResponseMessage response) : HttpResponseMessageAssertorBase<HttpResponseMessageAssertor>(owner, logs, response)
     {
         /// <summary>
         /// Asserts the the <see cref="HttpResponseMessageAssertorBase.Response"/> <see cref="HttpResponseMessage.Headers"/> <see cref="HeaderNames.Location"/> matches the <paramref name="expectedUri"/>.

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBase.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Mime;
 using UnitTestEx.Abstractions;
@@ -15,13 +16,19 @@ namespace UnitTestEx.Assertors
     /// Initializes a new instance of the <see cref="HttpResponseMessageAssertorBase{TSelf}"/> class.
     /// </remarks>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="logs">The log messages captured during execution.</param>
     /// <param name="response">The <see cref="HttpResponseMessage"/>.</param>
-    public abstract class HttpResponseMessageAssertorBase(TesterBase owner, HttpResponseMessage response)
+    public abstract class HttpResponseMessageAssertorBase(TesterBase owner, IEnumerable<string?>? logs, HttpResponseMessage response)
     {
         /// <summary>
         /// Gets the owning <see cref="TesterBase"/>.
         /// </summary>
         public TesterBase Owner { get; } = owner ?? throw new ArgumentNullException(nameof(owner));
+
+        /// <summary>
+        /// Gets the log messages captured during execution.
+        /// </summary>
+        public IEnumerable<string?> LogMessages { get; } = logs ?? [];
 
         /// <summary>
         /// Gets the <see cref="HttpResponseMessage"/>.

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorBaseT.cs
@@ -17,8 +17,9 @@ namespace UnitTestEx.Assertors
     /// Provides the base <see cref="HttpResponseMessage"/> test assert helper capabilities.
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="logs">The log messages captured during execution.</param>
     /// <param name="response">The <see cref="HttpResponseMessage"/>.</param>
-    public abstract class HttpResponseMessageAssertorBase<TSelf>(TesterBase owner, HttpResponseMessage response) : HttpResponseMessageAssertorBase(owner, response) where TSelf : HttpResponseMessageAssertorBase<TSelf>
+    public abstract class HttpResponseMessageAssertorBase<TSelf>(TesterBase owner, IEnumerable<string?>? logs, HttpResponseMessage response) : HttpResponseMessageAssertorBase(owner, logs, response) where TSelf : HttpResponseMessageAssertorBase<TSelf>
     {
         /// <summary>
         /// Asserts that the <see cref="HttpResponseMessage.StatusCode"/> has a successful value between 200 and 299.

--- a/src/UnitTestEx/Assertors/HttpResponseMessageAssertorT.cs
+++ b/src/UnitTestEx/Assertors/HttpResponseMessageAssertorT.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Net.Http.Headers;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using UnitTestEx.Abstractions;
 
@@ -11,8 +12,9 @@ namespace UnitTestEx.Assertors
     /// Represents the <see cref="HttpResponseMessage"/> test assert helper with a specified response <typeparamref name="TValue"/> <see cref="Type"/>.
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="logs">The log messages captured during execution.</param>
     /// <param name="response">The <see cref="HttpResponseMessage"/>.</param>
-    public class HttpResponseMessageAssertor<TValue>(TesterBase owner, HttpResponseMessage response) : HttpResponseMessageAssertorBase<HttpResponseMessageAssertor<TValue>>(owner, response)
+    public class HttpResponseMessageAssertor<TValue>(TesterBase owner, IEnumerable<string?>? logs, HttpResponseMessage response) : HttpResponseMessageAssertorBase<HttpResponseMessageAssertor<TValue>>(owner, logs, response)
     {
         private TValue? _value;
         private bool _valueIsDeserialized;
@@ -21,9 +23,10 @@ namespace UnitTestEx.Assertors
         /// Initializes a new instance of the <see cref="HttpResponseMessageAssertor"/> class.
         /// </summary>
         /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+        /// <param name="logs">The log messages captured during execution.</param>
         /// <param name="value">The value already deserialized.</param>
         /// <param name="response">The <see cref="HttpResponseMessage"/>.</param>
-        public HttpResponseMessageAssertor(TesterBase owner, TValue value, HttpResponseMessage response) : this(owner, response)
+        public HttpResponseMessageAssertor(TesterBase owner, IEnumerable<string?>? logs, TValue value, HttpResponseMessage response) : this(owner, logs, response)
         {
             _value = value;
             _valueIsDeserialized = true;
@@ -33,7 +36,7 @@ namespace UnitTestEx.Assertors
         /// Initializes a new instance of the <see cref="HttpResponseMessageAssertor"/> class.
         /// </summary>
         /// <param name="assertor">The untyped <see cref="HttpResponseMessageAssertor"/>.</param>
-        internal HttpResponseMessageAssertor(HttpResponseMessageAssertor assertor) : this(assertor.Owner, assertor.Response) { }
+        internal HttpResponseMessageAssertor(HttpResponseMessageAssertor assertor) : this(assertor.Owner, assertor.LogMessages, assertor.Response) { }
 
         /// <summary>
         /// Gets the response content as the deserialized JSON value.

--- a/src/UnitTestEx/Assertors/HttpResultAssertor.cs
+++ b/src/UnitTestEx/Assertors/HttpResultAssertor.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Http;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
@@ -16,8 +17,9 @@ namespace UnitTestEx.Assertors
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
     /// <param name="result">The <see cref="IResult"/>.</param>
+    /// <param name="logs">The logs captured during execution.</param>
     /// <param name="exception">The <see cref="Exception"/> (if any).</param>
-    public class HttpResultAssertor(TesterBase owner, IResult result, Exception? exception) : AssertorBase<HttpResultAssertor>(owner, exception)
+    public class HttpResultAssertor(TesterBase owner, IResult result, IEnumerable<string?>? logs, Exception? exception) : AssertorBase<HttpResultAssertor>(owner, logs, exception)
     {
         /// <summary>
         /// Gets the <see cref="IResult"/>.
@@ -29,16 +31,17 @@ namespace UnitTestEx.Assertors
         /// </summary>
         /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/> with <see cref="HttpContext"/>; otherwise, will default.</param>
         /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
-        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor(HttpRequest? httpRequest = null) => ToHttpResponseMessageAssertor(Owner, Result, httpRequest);
+        public HttpResponseMessageAssertor ToHttpResponseMessageAssertor(HttpRequest? httpRequest = null) => ToHttpResponseMessageAssertor(Owner, Result, LogMessages, httpRequest);
 
         /// <summary>
         /// Converts the <see cref="ValueAssertor{TValue}"/> to an <see cref="HttpResponseMessageAssertor"/>.
         /// </summary>
         /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
         /// <param name="result">The <see cref="IResult"/> to convert.</param>
-        /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/>; otherwise, will default.</param>
+        /// <param name="logs">The log messages captured during execution.</param>
+        /// <param name="httpRequest">The optional requesting <see cref="HttpRequest"/> with <see cref="HttpContext"/>; otherwise, will default.</param>
         /// <returns>The corresponding <see cref="HttpResponseMessageAssertor"/>.</returns>
-        internal static HttpResponseMessageAssertor ToHttpResponseMessageAssertor(TesterBase owner, IResult result, HttpRequest? httpRequest)
+        internal static HttpResponseMessageAssertor ToHttpResponseMessageAssertor(TesterBase owner, IResult result, IEnumerable<string?>? logs, HttpRequest? httpRequest)
         {
             var sw = Stopwatch.StartNew();
             using var ms = new MemoryStream();
@@ -61,7 +64,7 @@ namespace UnitTestEx.Assertors
             sw.Stop();
             owner.LogHttpResponseMessage(hr, sw);
 
-            return new HttpResponseMessageAssertor(owner, hr);
+            return new HttpResponseMessageAssertor(owner, logs, hr);
         }
     }
 }

--- a/src/UnitTestEx/Assertors/ValueAssertor.cs
+++ b/src/UnitTestEx/Assertors/ValueAssertor.cs
@@ -3,6 +3,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Reflection;
@@ -16,8 +17,9 @@ namespace UnitTestEx.Assertors
     /// <typeparam name="TValue">The result value <see cref="Type"/>.</typeparam>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
     /// <param name="value">The result value.</param>
+    /// <param name="logs">The logs captured during execution.</param>
     /// <param name="exception">The <see cref="Exception"/> (if any).</param>
-    public class ValueAssertor<TValue>(TesterBase owner, TValue value, Exception? exception) : AssertorBase<ValueAssertor<TValue>>(owner, exception)
+    public class ValueAssertor<TValue>(TesterBase owner, TValue value, IEnumerable<string?>? logs, Exception? exception) : AssertorBase<ValueAssertor<TValue>>(owner, logs, exception)
     {
         /// <summary>
         /// Gets the resulting value.
@@ -93,7 +95,7 @@ namespace UnitTestEx.Assertors
         public ActionResultAssertor ToActionResultAssertor()
         {
             if (typeof(IActionResult).IsAssignableFrom(typeof(TValue)))
-                return new ActionResultAssertor(Owner, (IActionResult)Value!, Exception);
+                return new ActionResultAssertor(Owner, (IActionResult)Value!, LogMessages, Exception);
 
             throw new InvalidOperationException($"Result Type '{typeof(TValue).Name}' must be assignable from '{nameof(IActionResult)}'");
         }
@@ -109,13 +111,13 @@ namespace UnitTestEx.Assertors
             if (Value != null)
             {
                 if (Value is HttpResponseMessage hrm)
-                    return new HttpResponseMessageAssertor(Owner, hrm);
+                    return new HttpResponseMessageAssertor(Owner, LogMessages, hrm);
 
                 if (Value is IActionResult ar)
-                    return ActionResultAssertor.ToHttpResponseMessageAssertor(Owner, ar, httpRequest);
+                    return ActionResultAssertor.ToHttpResponseMessageAssertor(Owner, ar, LogMessages, httpRequest);
 #if NET7_0_OR_GREATER
                 if (Value is IResult ir)
-                    return HttpResultAssertor.ToHttpResponseMessageAssertor(Owner, ir, httpRequest);
+                    return HttpResultAssertor.ToHttpResponseMessageAssertor(Owner, ir, LogMessages, httpRequest);
 #endif
             }
 

--- a/src/UnitTestEx/Assertors/VoidAssertor.cs
+++ b/src/UnitTestEx/Assertors/VoidAssertor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/UnitTestEx
 
 using System;
+using System.Collections.Generic;
 using UnitTestEx.Abstractions;
 
 namespace UnitTestEx.Assertors
@@ -9,6 +10,7 @@ namespace UnitTestEx.Assertors
     /// Represents the test assert helper where there is no return value; i.e. <see cref="void"/>.
     /// </summary>
     /// <param name="owner">The owning <see cref="TesterBase"/>.</param>
+    /// <param name="logs">The logs captured during execution.</param>
     /// <param name="exception">The <see cref="Exception"/> (if any).</param>
-    public class VoidAssertor(TesterBase owner, Exception? exception) : AssertorBase<VoidAssertor>(owner, exception) { }
+    public class VoidAssertor(TesterBase owner, IEnumerable<string?>? logs, Exception? exception) : AssertorBase<VoidAssertor>(owner, logs, exception) { }
 }

--- a/src/UnitTestEx/Generic/GenericTesterBase.cs
+++ b/src/UnitTestEx/Generic/GenericTesterBase.cs
@@ -270,7 +270,7 @@ namespace UnitTestEx.Generic
 
             await ExpectationsArranger.AssertAsync(messages, exception).ConfigureAwait(false);
 
-            return new VoidAssertor(this, exception);
+            return new VoidAssertor(this, messages, exception);
         }
 
 #if NET9_0_OR_GREATER
@@ -563,7 +563,7 @@ namespace UnitTestEx.Generic
 
             await ExpectationsArranger.AssertAsync(messages, exception).ConfigureAwait(false);
 
-            return new ValueAssertor<TValue>(this, value, exception);
+            return new ValueAssertor<TValue>(this, value, messages, exception);
         }
 
 #if NET9_0_OR_GREATER

--- a/src/UnitTestEx/Generic/GenericTesterBaseT.cs
+++ b/src/UnitTestEx/Generic/GenericTesterBaseT.cs
@@ -146,7 +146,7 @@ namespace UnitTestEx.Generic
 
             await ExpectationsArranger.AssertAsync(messages, exception).ConfigureAwait(false);
 
-            return new ValueAssertor<TValue>(this, value, exception);
+            return new ValueAssertor<TValue>(this, value, messages, exception);
         }
     }
 }

--- a/src/UnitTestEx/Hosting/ScopedTypeTester.cs
+++ b/src/UnitTestEx/Hosting/ScopedTypeTester.cs
@@ -134,7 +134,7 @@ public class ScopedTypeTester<TService> : HostTesterBase<TService, ScopedTypeTes
             if (!args.BypassRunActions)
                 Owner.ExecutePostRunAfterExpectationsActions(this);
 
-            return new VoidAssertor(Owner, ex);
+            return new VoidAssertor(Owner, logs, ex);
         }
         finally
         {
@@ -248,7 +248,7 @@ public class ScopedTypeTester<TService> : HostTesterBase<TService, ScopedTypeTes
             if (!args.BypassRunActions)
                 Owner.ExecutePostRunAfterExpectationsActions(this);
 
-            return new ValueAssertor<TValue>(Owner, result, ex);
+            return new ValueAssertor<TValue>(Owner, result, logs, ex);
         }
         finally
         {

--- a/src/UnitTestEx/Hosting/TypeTester.cs
+++ b/src/UnitTestEx/Hosting/TypeTester.cs
@@ -137,7 +137,7 @@ namespace UnitTestEx.Hosting
 
             await ExpectationsArranger.AssertAsync(logs, ex).ConfigureAwait(false);
 
-            return new VoidAssertor(Owner, ex);
+            return new VoidAssertor(Owner, logs, ex);
         }
 
 #if NET9_0_OR_GREATER
@@ -229,7 +229,7 @@ namespace UnitTestEx.Hosting
 
             await ExpectationsArranger.AssertValueAsync(logs, result, ex).ConfigureAwait(false);
 
-            return new ValueAssertor<TValue>(Owner, result, ex);
+            return new ValueAssertor<TValue>(Owner, result, logs, ex);
         }
 
 #if NET9_0_OR_GREATER

--- a/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/PersonControllerTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using UnitTestEx.Api;
@@ -196,21 +197,28 @@ namespace UnitTestEx.NUnit.Test
         public void Update_Test7_ExpectationFailure2()
         {
             using var test = ApiTester.Create<Startup>();
-            test.Controller<PersonController>()
+            var assertor = test.Controller<PersonController>()
                 .ExpectStatusCode(System.Net.HttpStatusCode.BadRequest)
                 .ExpectError("No can do eighty-eight.")
                 .Run(c => c.Update(88, new Person { FirstName = null, LastName = null }));
+
+            Assert.That(assertor, Is.Not.Null);
+            Assert.That(assertor.LogMessages, Is.Not.Null);
         }
 
         [Test]
         public async Task Http_Get1()
         {
             using var test = ApiTester.Create<Startup>();
-            (await test.Http()
+            var assertor = (await test.Http()
                 .ExpectLogContains("Get using identifier 1")
                 .RunAsync(HttpMethod.Get, "Person/1" ))
                 .AssertOK()
                 .AssertValue(new Person { Id = 1, FirstName = "Bob", LastName = "Smith" });
+
+            Assert.That(assertor, Is.Not.Null);
+            Assert.That(assertor.LogMessages, Is.Not.Null);
+            Assert.That(assertor.LogMessages.Count(m => m.Contains("Get using identifier 1")), Is.EqualTo(1), "Expected log message was not found exactly once.");
         }
 
         [Test]
@@ -318,10 +326,13 @@ namespace UnitTestEx.NUnit.Test
 
             var iar = new OkResult();
 
-            new Assertors.ValueAssertor<IActionResult>(test, iar, null)
+            var valueAssertor = new Assertors.ValueAssertor<IActionResult>(test, iar, [], null)
                 .ToHttpResponseMessageAssertor(hr)
                 .AssertNamedHeader("X-Test", "Test")
                 .AssertNoNamedHeader("X-Absent");
+
+            Assert.That(valueAssertor, Is.Not.Null);
+            Assert.That(valueAssertor.LogMessages, Is.Not.Null);
         }
     }
 }

--- a/tests/UnitTestEx.NUnit.Test/ProductFunctionTest.cs
+++ b/tests/UnitTestEx.NUnit.Test/ProductFunctionTest.cs
@@ -3,6 +3,7 @@ using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Moq;
 using NUnit.Framework;
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using UnitTestEx.Expectations;
@@ -35,12 +36,14 @@ namespace UnitTestEx.NUnit.Test
                 .Request(HttpMethod.Get, "products/abc").Respond.WithJson(new { id = "Abc", description = "A blue carrot" });
 
             using var test = FunctionTester.Create<Startup>();
-            test.ReplaceHttpClientFactory(mcf)
+            var assertor =test.ReplaceHttpClientFactory(mcf)
                 .HttpTrigger<ProductFunction>()
                 .ExpectLogContains("C# HTTP trigger function processed a request.")
                 .Run(f => f.Run(test.CreateHttpRequest(HttpMethod.Get, "product/abc"), "abc", test.Logger))
                 .AssertOK()
                 .AssertValue(new { id = "Abc", description = "A blue carrot" });
+
+            Assert.That(assertor.LogMessages.Count(m => m.Contains("C# HTTP trigger function processed a request.")), Is.EqualTo(1), "Expected log message was not found exactly once.");
         }
 
         [Test]


### PR DESCRIPTION
- *Enhancement:* Added `AssertorBase.Logs` to enable access to the logs captured during execution of the test for assertion purposes. This is intended to be used in conjunction with the existing `ExpectLogContains` expectation to enable additional (more advanced) assertions against the logs.